### PR TITLE
Change value of global property key to enable receipt generation for a saved bill

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
+++ b/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
@@ -39,7 +39,7 @@ public class ModuleSettings {
 	
 	public static final String ROUNDING_DEPT_ID = "cashier.roundingDeptId";
 	
-	public static final String SYSTEM_RECEIPT_NUMBER_GENERATOR = "cashier.systemReceiptNumberGenerator";
+	public static final String SYSTEM_RECEIPT_NUMBER_GENERATOR = "billing.systemReceiptNumberGenerator";
 	
 	public static final String ADJUSTMENT_REASEON_FIELD = "cashier.adjustmentReasonField";
 	

--- a/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
+++ b/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
-
+	
 	private static final Log LOG = LogFactory.getLog(GenerateBillFromOrderAdvice.class);
 	
 	OrderService orderService = Context.getOrderService();
@@ -238,7 +238,7 @@ public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
 			
 		}
 		catch (Exception ex) {
-			LOG.error("Error sending the bill item: " + ex.getMessage(), ex);			
+			LOG.error("Error sending the bill item: " + ex.getMessage(), ex);
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/exemptions/BillingExemptionChecker.java
+++ b/api/src/main/java/org/openmrs/module/billing/exemptions/BillingExemptionChecker.java
@@ -3,24 +3,24 @@ package org.openmrs.module.billing.exemptions;
 import java.util.Set;
 
 public class BillingExemptionChecker {
-
-    /**
-     * Checks if a given concept ID is exempted from billing under the provided category.
-     *
-     * @param category The category to check (e.g., "services" or "commodities")
-     * @param key      The specific key within the category (e.g., "program:HIV")
-     * @param conceptId The concept ID to check for exemption
-     * @return true if the concept ID is exempted, false otherwise
-     */
-    public boolean isExempted(String category, String key, Integer conceptId) {
-        Set<Integer> exemptedConcepts;
-        if (category.equals("services")) {
-            exemptedConcepts = BillingExemptions.SERVICES.get(key);
-        } else if (category.equals("commodities")) {
-            exemptedConcepts = BillingExemptions.COMMODITIES.get(key);
-        } else {
-            return false;
-        }
-        return exemptedConcepts != null && exemptedConcepts.contains(conceptId);
-    }
+	
+	/**
+	 * Checks if a given concept ID is exempted from billing under the provided category.
+	 *
+	 * @param category The category to check (e.g., "services" or "commodities")
+	 * @param key The specific key within the category (e.g., "program:HIV")
+	 * @param conceptId The concept ID to check for exemption
+	 * @return true if the concept ID is exempted, false otherwise
+	 */
+	public boolean isExempted(String category, String key, Integer conceptId) {
+		Set<Integer> exemptedConcepts;
+		if (category.equals("services")) {
+			exemptedConcepts = BillingExemptions.SERVICES.get(key);
+		} else if (category.equals("commodities")) {
+			exemptedConcepts = BillingExemptions.COMMODITIES.get(key);
+		} else {
+			return false;
+		}
+		return exemptedConcepts != null && exemptedConcepts.contains(conceptId);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/exemptions/BillingExemptionsConfig.java
+++ b/api/src/main/java/org/openmrs/module/billing/exemptions/BillingExemptionsConfig.java
@@ -4,23 +4,25 @@ import java.util.Map;
 import java.util.Set;
 
 public class BillingExemptionsConfig {
-    private Map<String, Set<Integer>> services;
-    private Map<String, Set<Integer>> commodities;
-
-    // Getters and setters
-    public Map<String, Set<Integer>> getServices() {
-        return services;
-    }
-
-    public void setServices(Map<String, Set<Integer>> services) {
-        this.services = services;
-    }
-
-    public Map<String, Set<Integer>> getCommodities() {
-        return commodities;
-    }
-
-    public void setCommodities(Map<String, Set<Integer>> commodities) {
-        this.commodities = commodities;
-    }
+	
+	private Map<String, Set<Integer>> services;
+	
+	private Map<String, Set<Integer>> commodities;
+	
+	// Getters and setters
+	public Map<String, Set<Integer>> getServices() {
+		return services;
+	}
+	
+	public void setServices(Map<String, Set<Integer>> services) {
+		this.services = services;
+	}
+	
+	public Map<String, Set<Integer>> getCommodities() {
+		return commodities;
+	}
+	
+	public void setCommodities(Map<String, Set<Integer>> commodities) {
+		this.commodities = commodities;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/exemptions/DefaultBillingExemptions.java
+++ b/api/src/main/java/org/openmrs/module/billing/exemptions/DefaultBillingExemptions.java
@@ -9,23 +9,24 @@ import java.io.File;
 import java.io.IOException;
 
 public class DefaultBillingExemptions extends BillingExemptions {
-
-    private static final Log LOG = LogFactory.getLog(DefaultBillingExemptions.class);
-
-    private static final String CONFIG_FILE_PATH = "/billing/exemptions/SampleBillingExemptions.json";
-
-    @Override
-    public void buildBillingExemptionList() {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            BillingExemptionsConfig config = mapper.readValue(new File(CONFIG_FILE_PATH), BillingExemptionsConfig.class);
-
-            setSERVICES(config.getServices());
-            setCOMMODITIES(config.getCommodities());
-
-        } catch (IOException e) {
-            LOG.error("Failed to load billing exemptions from " + CONFIG_FILE_PATH + ": " + e.getMessage()); 
-            throw new RuntimeException("Unable to load billing exemptions", e);
-        }
-    }
+	
+	private static final Log LOG = LogFactory.getLog(DefaultBillingExemptions.class);
+	
+	private static final String CONFIG_FILE_PATH = "/billing/exemptions/SampleBillingExemptions.json";
+	
+	@Override
+	public void buildBillingExemptionList() {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			BillingExemptionsConfig config = mapper.readValue(new File(CONFIG_FILE_PATH), BillingExemptionsConfig.class);
+			
+			setSERVICES(config.getServices());
+			setCOMMODITIES(config.getCommodities());
+			
+		}
+		catch (IOException e) {
+			LOG.error("Failed to load billing exemptions from " + CONFIG_FILE_PATH + ": " + e.getMessage());
+			throw new RuntimeException("Unable to load billing exemptions", e);
+		}
+	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/exemptions/SampleBillingExemptionBuilder.java
+++ b/api/src/main/java/org/openmrs/module/billing/exemptions/SampleBillingExemptionBuilder.java
@@ -15,103 +15,112 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
+
 /*
  * Builds a list of exemptions from json file
 */
 public class SampleBillingExemptionBuilder extends BillingExemptions {
-
-    private static final Log LOG = LogFactory.getLog(SampleBillingExemptionBuilder.class);
-
-    public SampleBillingExemptionBuilder() {
-    }
-
-    @Override
-    public void buildBillingExemptionList() {
-        GlobalProperty gpConfiguredFilePath = Context.getAdministrationService()
-                .getGlobalPropertyObject(CashierModuleConstants.BILLING_EXEMPTIONS_CONFIG_FILE_PATH);
-        if (gpConfiguredFilePath == null || StringUtils.isBlank(gpConfiguredFilePath.getPropertyValue())) {
-            try {
-                initializeExemptionsConfig();
-            } catch (Exception e) {
-                LOG.error("Billing exemptions have not been configured...", e);
-            }
-            return;
-        }
-        String configurationFilePath = gpConfiguredFilePath.getPropertyValue();
-        FileInputStream fileInputStream;
-        ObjectNode config = null;
-        try {
-            fileInputStream = new FileInputStream(configurationFilePath);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            try {
-                initializeExemptionsConfig();
-            } catch (Exception ex) {
-                LOG.error("The configuration file for billing exemptions was found, but could not be processed", ex);
-            }
-            return;
-        }
-
-        if (fileInputStream != null) {
-            ObjectMapper mapper = new ObjectMapper();
-            try {
-                config = mapper.readValue(fileInputStream, ObjectNode.class);
-            } catch (IOException e) {
-                e.printStackTrace();
-                try {
-                    initializeExemptionsConfig();
-                } catch (Exception ex) {
-                    LOG.error("The configuration file for billing exemptions was found, but could not be understood. Check that the JSON object is well formed", ex);
-                }
-                return;
-            }
-        }
-
-        if (config != null) {
-            ObjectNode configuredServices = (ObjectNode) config.get("services");
-            ObjectNode commodities = (ObjectNode) config.get("commodities");
-
-            if (configuredServices != null) {
-                Map<String, Set<Integer>> exemptedServices = mapConcepts(configuredServices);
-                BillingExemptions.setSERVICES(exemptedServices);
-            }
-
-            if (commodities != null) {
-                Map<String, Set<Integer>> exemptedCommodities = mapConcepts(commodities);
-                BillingExemptions.setCOMMODITIES(exemptedCommodities);
-            }
-        } else {
-            initializeExemptionsConfig();
-        }
-    }
-
-    private Map<String, Set<Integer>> mapConcepts(ObjectNode node) {
-        Map<String, Set<Integer>> exemptionList = new HashMap<>();
-        if (node != null) {
-            Iterator<Map.Entry<String, JsonNode>> iterator = node.getFields();
-            iterator.forEachRemaining(entry -> {
-                Set<Integer> conceptSet = new HashSet<>();
-                String key = entry.getKey();
-                ArrayNode conceptIds = (ArrayNode) entry.getValue();
-                if (conceptIds.isArray() && conceptIds.size() > 0) {
-                    for (int i = 0; i < conceptIds.size(); i++) {
-                        try {
-                            conceptSet.add(conceptIds.get(i).getIntValue());
-                        } catch (Exception e) {
-                            LOG.error("Error converting concept ID to integer: " + conceptIds.get(i).toString(), e);
-                        }
-                    }
-                }
-                if (conceptSet.size() > 0) {
-                    exemptionList.put(key, conceptSet);
-                }
-            });
-        }
-        return exemptionList;
-    }
-
-    private void initializeExemptionsConfig() {
-        BillingExemptions.setCOMMODITIES(new HashMap<>());
-        BillingExemptions.setSERVICES(new HashMap<>());
-    }
+	
+	private static final Log LOG = LogFactory.getLog(SampleBillingExemptionBuilder.class);
+	
+	public SampleBillingExemptionBuilder() {
+	}
+	
+	@Override
+	public void buildBillingExemptionList() {
+		GlobalProperty gpConfiguredFilePath = Context.getAdministrationService()
+		        .getGlobalPropertyObject(CashierModuleConstants.BILLING_EXEMPTIONS_CONFIG_FILE_PATH);
+		if (gpConfiguredFilePath == null || StringUtils.isBlank(gpConfiguredFilePath.getPropertyValue())) {
+			try {
+				initializeExemptionsConfig();
+			}
+			catch (Exception e) {
+				LOG.error("Billing exemptions have not been configured...", e);
+			}
+			return;
+		}
+		String configurationFilePath = gpConfiguredFilePath.getPropertyValue();
+		FileInputStream fileInputStream;
+		ObjectNode config = null;
+		try {
+			fileInputStream = new FileInputStream(configurationFilePath);
+		}
+		catch (FileNotFoundException e) {
+			e.printStackTrace();
+			try {
+				initializeExemptionsConfig();
+			}
+			catch (Exception ex) {
+				LOG.error("The configuration file for billing exemptions was found, but could not be processed", ex);
+			}
+			return;
+		}
+		
+		if (fileInputStream != null) {
+			ObjectMapper mapper = new ObjectMapper();
+			try {
+				config = mapper.readValue(fileInputStream, ObjectNode.class);
+			}
+			catch (IOException e) {
+				e.printStackTrace();
+				try {
+					initializeExemptionsConfig();
+				}
+				catch (Exception ex) {
+					LOG.error(
+					    "The configuration file for billing exemptions was found, but could not be understood. Check that the JSON object is well formed",
+					    ex);
+				}
+				return;
+			}
+		}
+		
+		if (config != null) {
+			ObjectNode configuredServices = (ObjectNode) config.get("services");
+			ObjectNode commodities = (ObjectNode) config.get("commodities");
+			
+			if (configuredServices != null) {
+				Map<String, Set<Integer>> exemptedServices = mapConcepts(configuredServices);
+				BillingExemptions.setSERVICES(exemptedServices);
+			}
+			
+			if (commodities != null) {
+				Map<String, Set<Integer>> exemptedCommodities = mapConcepts(commodities);
+				BillingExemptions.setCOMMODITIES(exemptedCommodities);
+			}
+		} else {
+			initializeExemptionsConfig();
+		}
+	}
+	
+	private Map<String, Set<Integer>> mapConcepts(ObjectNode node) {
+		Map<String, Set<Integer>> exemptionList = new HashMap<>();
+		if (node != null) {
+			Iterator<Map.Entry<String, JsonNode>> iterator = node.getFields();
+			iterator.forEachRemaining(entry -> {
+				Set<Integer> conceptSet = new HashSet<>();
+				String key = entry.getKey();
+				ArrayNode conceptIds = (ArrayNode) entry.getValue();
+				if (conceptIds.isArray() && conceptIds.size() > 0) {
+					for (int i = 0; i < conceptIds.size(); i++) {
+						try {
+							conceptSet.add(conceptIds.get(i).getIntValue());
+						}
+						catch (Exception e) {
+							LOG.error("Error converting concept ID to integer: " + conceptIds.get(i).toString(), e);
+						}
+					}
+				}
+				if (conceptSet.size() > 0) {
+					exemptionList.put(key, conceptSet);
+				}
+			});
+		}
+		return exemptionList;
+	}
+	
+	private void initializeExemptionsConfig() {
+		BillingExemptions.setCOMMODITIES(new HashMap<>());
+		BillingExemptions.setSERVICES(new HashMap<>());
+	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/exemptions/SampleBillingExemptions.json
+++ b/api/src/main/java/org/openmrs/module/billing/exemptions/SampleBillingExemptions.json
@@ -1,49 +1,49 @@
 {
-    "services": {
-        "all": [
+    "services" : {
+        "all" : [
             {
-                "id": "167410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "Clinical Consultation"
+                "id" : "167410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "Clinical Consultation"
             },
             {
-                "id": "160542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "Outpatient Department"
+                "id" : "160542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "Outpatient Department"
             }
         ],
-        "program:HIV": [
+        "program:HIV" : [
             {
-                "id": "855e254f-a5db-4760-88b3-26c3d0cdda14",
-                "description": "HIV Consultation"
+                "id" : "855e254f-a5db-4760-88b3-26c3d0cdda14",
+                "description" : "HIV Consultation"
             }
         ],
-        "program:TB": [
+        "program:TB" : [
             {
-                "id": "855e254f-a5db-4760-88b3-26c3d0cdda14",
-                "description": "TB Treatment"
+                "id" : "855e254f-a5db-4760-88b3-26c3d0cdda14",
+                "description" : "TB Treatment"
             }
         ],
-        "age<5": [
+        "age<5" : [
             {
-                "id": "160537AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "Pediatric Consultation"
+                "id" : "160537AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "Pediatric Consultation"
             },
             {
-                "id": "1283AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "Labaratory Orders"
+                "id" : "1283AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "Labaratory Orders"
             }
-        ]        
+        ]
     },
-    "commodities": {
-        "all": [
+    "commodities" : {
+        "all" : [
             {
-                "id": "164103AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "General Commodity"
+                "id" : "164103AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "General Commodity"
             }
         ],
-        "program:HIV": [
+        "program:HIV" : [
             {
-                "id": "161187AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "description": "HIV Test Kits"
+                "id" : "161187AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "description" : "HIV Test Kits"
             }
         ]
     }


### PR DESCRIPTION
The receipt generator was failing for saved bills because within the `ModuleSettings.SYSTEM_RECEIPT_NUMBER_GENERATOR`, the global property key for this string was `cashier.systemReceiptNumberGenerator` which is not what the [config.xml](https://github.com/openmrs/openmrs-module-billing/blob/490beda6a904497944f52f547374250b9215c57e/omod/src/main/resources/config.xml#L72) supports. This PR renames it to `billing.systemReceiptNumberGenerator` that provides a value tested via this endpoint `/ws/rest/v1/systemsetting/billing.systemReceiptNumberGenerator` as compared to `/ws/rest/v1/systemsetting/cashier.systemReceiptNumberGenerator` that would return an error.

PS: The global property in the admin UI needs to be `org.openmrs.module.billing.api.SequentialReceiptNumberGenerator` which is the fully qualified class name to enable SYSTEM_RECEIPT_NUMBER_GENERATOR to be triggered for creating receipt numbers on the O3 UI and ability to download payment receipts