### PR TITLE
Correctly Handle UUID in defaultLocation global property

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/util/Utils.java
+++ b/api/src/main/java/org/openmrs/module/billing/util/Utils.java
@@ -73,13 +73,17 @@ public class Utils {
 			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
 			String GP_DEFAULT_LOCATION = "defaultLocation";
 			GlobalProperty gp = Context.getAdministrationService().getGlobalPropertyObject(GP_DEFAULT_LOCATION);
-			return gp != null ? ((Location) gp.getValue()) : null;
+			// Check if gp value is a UUID string and fetch the Location by UUID
+			if (gp != null && gp.getValue() instanceof String) {
+				return Context.getLocationService().getLocationByUuid((String) gp.getValue());
+			} else {
+				return gp != null ? (Location) gp.getValue() : null;
+			}
 		}
 		finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.GET_LOCATIONS);
 			Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
 		}
-		
 	}
 	
 	/**


### PR DESCRIPTION
This is a fix to enable correctly handling UUID in defaultLocation global property in Utils.getDefaultLocation()

- Modified `Utils.getDefaultLocation()` to handle cases where the global property `defaultLocation` is stored as a UUID string instead of a `Location` object.
- Added logic to fetch `Location` by UUID if the global property value is a string.
- Ensured null safety to prevent potential NullPointerExceptions in modules relying on this utility.
