### PR TITLE
feat: Add functionality to check if a payment mode is in use before deletion

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/IPaymentModeService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/IPaymentModeService.java
@@ -18,8 +18,14 @@ import org.openmrs.module.billing.api.base.entity.IMetadataDataService;
 import org.openmrs.module.billing.api.model.PaymentMode;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Interface that represents classes which perform data operations for {@link PaymentMode}s.
- */
 @Transactional
-public interface IPaymentModeService extends IMetadataDataService<PaymentMode> {}
+public interface IPaymentModeService extends IMetadataDataService<PaymentMode> {
+	
+	/**
+	 * Check if a payment mode is currently in use.
+	 *
+	 * @param paymentModeId The ID of the payment mode to check.
+	 * @return True if the payment mode is in use, false otherwise.
+	 */
+	boolean isPaymentModeInUse(Integer paymentModeId);
+}

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/PaymentModeCustomController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/PaymentModeCustomController.java
@@ -1,0 +1,43 @@
+package org.openmrs.module.billing.web.legacyweb.controller;
+
+import org.openmrs.module.billing.api.IPaymentModeService;
+import org.openmrs.module.billing.api.model.PaymentMode;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Controller
+@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/billing/paymentMode")
+public class PaymentModeCustomController {
+
+    @Autowired
+    private IPaymentModeService paymentModeService;
+
+    /**
+     * Custom endpoint to check if a payment mode is in use.
+     *
+     * @param uuid The UUID of the payment mode to check.
+     * @return A JSON response indicating if the payment mode is in use.
+     */
+    @GetMapping("/isInUse/{uuid}")
+    public ResponseEntity<Map<String, Boolean>> isPaymentModeInUse(@PathVariable String uuid) {
+        Map<String, Boolean> response = new HashMap<>();
+
+        PaymentMode paymentMode = paymentModeService.getByUuid(uuid);
+        if (paymentMode == null) {
+            throw new IllegalArgumentException("PaymentMode with UUID " + uuid + " does not exist.");
+        }
+
+        boolean inUse = paymentModeService.isPaymentModeInUse(paymentMode.getId());
+        response.put("inUse", inUse);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -866,4 +866,21 @@
 			<column name="date_created"/>
 		</createIndex>
 	</changeSet>
+
+	<changeSet id="add-index-and-fk-for-payment-mode" author="odorajonathan">
+        <comment>Ensure database structure supports efficient payment mode usage checks</comment>
+
+        <!-- Add an index to optimize queries on payment_mode_id -->
+        <createIndex tableName="cashier_bill_payment" indexName="idx_cashier_bill_payment_payment_mode">
+            <column name="payment_mode_id"/>
+        </createIndex>
+
+        <!-- Add foreign key to ensure referential integrity -->
+        <addForeignKeyConstraint constraintName="fk_cashier_bill_payment_payment_mode"
+                                baseTableName="cashier_bill_payment"
+                                baseColumnNames="payment_mode_id"
+                                referencedTableName="cashier_payment_mode"
+                                referencedColumnNames="payment_mode_id"
+                                onDelete="CASCADE"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR takes care of adding the functionality to check if a payment mode is in use before deletion

- Updated IPaymentModeService to include isPaymentModeInUse method.
- Implemented isPaymentModeInUse in PaymentModeServiceImpl using Hibernate query.
- Enhanced PaymentModeCustomController with a new endpoint to check payment mode usage.
- Applied database optimizations with index and foreign key constraints for payment_mode_id.
- Ensured robust error handling for non-existent payment modes in the custom controller.