### PR TITLE
Fixed Bamboo Specs release-scripts repository checkout.

### DIFF
--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -61,10 +61,13 @@ Release to Maven:
   key: RTM
   tasks:
   - checkout:
-      repository: openmrs-module-billing.git
-      path: release-scripts
-      force-clean-build: false
+      force-clean-build: 'false'
       description: Checkout Default Repository
+  - checkout:
+      repository: Release scripts
+      path: release-scripts
+      force-clean-build: 'false'
+      description: Checkout Release Scripts Repository
   - script:
       interpreter: SHELL
       scripts:


### PR DESCRIPTION
Fixed Bamboo Specs release-scripts repository checkout: this basically resolves the missing folder for the release jobs.