### PR TITLE
Rename global property prefix from 'cashier' to 'billing'

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
+++ b/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
@@ -25,41 +25,41 @@ import org.openmrs.module.billing.api.model.CashierSettings;
  */
 public class ModuleSettings {
 	
-	public static final String RECEIPT_REPORT_ID_PROPERTY = "cashier.defaultReceiptReportId";
+	public static final String RECEIPT_REPORT_ID_PROPERTY = "billing.defaultReceiptReportId";
 	
-	public static final String CASHIER_SHIFT_REPORT_ID_PROPERTY = "cashier.defaultShiftReportId";
+	public static final String CASHIER_SHIFT_REPORT_ID_PROPERTY = "billing.defaultShiftReportId";
 	
-	public static final String TIMESHEET_REQUIRED_PROPERTY = "cashier.timesheetRequired";
+	public static final String TIMESHEET_REQUIRED_PROPERTY = "billing.timesheetRequired";
 	
-	public static final String ROUNDING_MODE_PROPERTY = "cashier.roundingMode";
+	public static final String ROUNDING_MODE_PROPERTY = "billing.roundingMode";
 	
-	public static final String ROUND_TO_NEAREST_PROPERTY = "cashier.roundToNearest";
+	public static final String ROUND_TO_NEAREST_PROPERTY = "billing.roundToNearest";
 	
-	public static final String ROUNDING_ITEM_ID = "cashier.roundingItemId";
+	public static final String ROUNDING_ITEM_ID = "billing.roundingItemId";
 	
-	public static final String ROUNDING_DEPT_ID = "cashier.roundingDeptId";
+	public static final String ROUNDING_DEPT_ID = "billing.roundingDeptId";
 	
 	public static final String SYSTEM_RECEIPT_NUMBER_GENERATOR = "billing.systemReceiptNumberGenerator";
 	
-	public static final String ADJUSTMENT_REASEON_FIELD = "cashier.adjustmentReasonField";
+	public static final String ADJUSTMENT_REASEON_FIELD = "billing.adjustmentReasonField";
 	
-	public static final String ALLOW_BILL_ADJUSTMENT = "cashier.allowBillAdjustments";
+	public static final String ALLOW_BILL_ADJUSTMENT = "billing.allowBillAdjustments";
 	
-	public static final String AUTOFILL_PAYMENT_AMOUNT = "cashier.autofillPaymentAmount";
+	public static final String AUTOFILL_PAYMENT_AMOUNT = "billing.autofillPaymentAmount";
 	
-	public static final String PATIENT_DASHBOARD_2_BILL_COUNT = "cashier.patientDashboard2BillCount";
+	public static final String PATIENT_DASHBOARD_2_BILL_COUNT = "billing.patientDashboard2BillCount";
 	
 	private static final Integer DEFAULT_PATIENT_DASHBOARD_2_BILL_COUNT = 4;
 	
-	public static final String DEPARTMENT_COLLECTIONS_REPORT_ID_PROPERTY = "cashier.reports.departmentCollections";
+	public static final String DEPARTMENT_COLLECTIONS_REPORT_ID_PROPERTY = "billing.reports.departmentCollections";
 	
-	public static final String DEPARTMENT_REVENUE_REPORT_ID_PROPERTY = "cashier.reports.departmentRevenue";
+	public static final String DEPARTMENT_REVENUE_REPORT_ID_PROPERTY = "billing.reports.departmentRevenue";
 	
-	public static final String SHIFT_SUMMARY_REPORT_ID_PROPERTY = "cashier.reports.shiftSummary";
+	public static final String SHIFT_SUMMARY_REPORT_ID_PROPERTY = "billing.reports.shiftSummary";
 	
-	public static final String DAILY_SHIFT_SUMMARY_REPORT_ID_PROPERTY = "cashier.reports.dailyShiftSummary";
+	public static final String DAILY_SHIFT_SUMMARY_REPORT_ID_PROPERTY = "billing.reports.dailyShiftSummary";
 	
-	public static final String PAYMENTS_BY_PAYMENT_MODE_REPORT_ID_PROPERTY = "cashier.reports.paymentsByPaymentMode";
+	public static final String PAYMENTS_BY_PAYMENT_MODE_REPORT_ID_PROPERTY = "billing.reports.paymentsByPaymentMode";
 	
 	private static final AdministrationService administrationService;
 	

--- a/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
+++ b/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
@@ -41,7 +41,7 @@ public class ModuleSettings {
 	
 	public static final String SYSTEM_RECEIPT_NUMBER_GENERATOR = "billing.systemReceiptNumberGenerator";
 	
-	public static final String ADJUSTMENT_REASEON_FIELD = "billing.adjustmentReasonField";
+	public static final String ADJUSTMENT_REASON_FIELD = "billing.adjustmentReasonField";
 	
 	public static final String ALLOW_BILL_ADJUSTMENT = "billing.allowBillAdjustments";
 	
@@ -77,7 +77,7 @@ public class ModuleSettings {
 	public static CashierSettings loadSettings() {
 		final CashierSettings cashierSettings = new CashierSettings();
 		
-		getBoolProperty(ADJUSTMENT_REASEON_FIELD, Boolean.FALSE, new Action1<Boolean>() {
+		getBoolProperty(ADJUSTMENT_REASON_FIELD, Boolean.FALSE, new Action1<Boolean>() {
 			
 			@Override
 			public void apply(Boolean parameter) {
@@ -194,7 +194,7 @@ public class ModuleSettings {
 			throw new IllegalArgumentException("The settings to save must be defined.");
 		}
 		
-		setBoolProperty(ADJUSTMENT_REASEON_FIELD, cashierSettings.getAdjustmentReasonField());
+		setBoolProperty(ADJUSTMENT_REASON_FIELD, cashierSettings.getAdjustmentReasonField());
 		setBoolProperty(ALLOW_BILL_ADJUSTMENT, cashierSettings.getAllowBillAdjustment());
 		setBoolProperty(AUTOFILL_PAYMENT_AMOUNT, cashierSettings.getAutoFillPaymentAmount());
 		setIntProperty(CASHIER_SHIFT_REPORT_ID_PROPERTY, cashierSettings.getDefaultShiftReportId());

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
@@ -325,7 +325,8 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 			if (file.exists()) {
 				try {
 					logoUrl = file.getAbsoluteFile().toURI().toURL();
-				} catch (MalformedURLException e) {
+				}
+				catch (MalformedURLException e) {
 					LOG.error("Error Loading file : " + logoUrl, e);
 				}
 			}

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/CashierOptionsTestInvalid.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/CashierOptionsTestInvalid.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-	<global_property property="cashier.roundToNearest" property_value=""/>
-	<global_property property="cashier.roundingItemId" property_value="asd"/>
+	<global_property property="billing.roundToNearest" property_value=""/>
+	<global_property property="billing.roundingItemId" property_value="asd"/>
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/CashierOptionsTestValid.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/CashierOptionsTestValid.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-	<global_property property="cashier.roundingItemUuid" property_value="4028814B399565AA01399681B1B5000E"/>
-	<global_property property="cashier.roundingMode" property_value="MID"/>
-	<global_property property="cashier.roundToNearest" property_value="5"/>
-	<global_property property="cashier.roundingItemId" property_value="2"/>
-	<global_property property="cashier.defaultReceiptReportId" property_value="3"/>
-	<global_property property="cashier.timesheetRequired" property_value="true"/>
+	<global_property property="billing.roundingItemUuid" property_value="4028814B399565AA01399681B1B5000E"/>
+	<global_property property="billing.roundingMode" property_value="MID"/>
+	<global_property property="billing.roundToNearest" property_value="5"/>
+	<global_property property="billing.roundingItemId" property_value="2"/>
+	<global_property property="billing.defaultReceiptReportId" property_value="3"/>
+	<global_property property="billing.timesheetRequired" property_value="true"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/BillAddEditController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/BillAddEditController.java
@@ -79,7 +79,7 @@ public class BillAddEditController {
         AdministrationService adminService = Context.getAdministrationService();
 
         boolean showAdjustmentReasonField = Boolean.parseBoolean(adminService.getGlobalProperty(
-                ModuleSettings.ADJUSTMENT_REASEON_FIELD));
+                ModuleSettings.ADJUSTMENT_REASON_FIELD));
         model.addAttribute("showAdjustmentReasonField", showAdjustmentReasonField);
 
         boolean allowBillAdjustment = Boolean.parseBoolean(adminService.getGlobalProperty(

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -868,4 +868,81 @@
 			<column name="date_created"/>
 		</createIndex>
 	</changeSet>
+
+	<changeSet id="openmrs.billing-001-v3.0.0-20251007" author="Wikum Weerakutti">
+		<comment>Migrate global properties from 'cashier.*' prefix to 'billing.*'</comment>
+
+		<update tableName="global_property">
+			<column name="property" value="billing.defaultReceiptReportId"/>
+			<where>property = 'cashier.defaultReceiptReportId'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.defaultShiftReportId"/>
+			<where>property = 'cashier.defaultShiftReportId'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.timesheetRequired"/>
+			<where>property = 'cashier.timesheetRequired'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.roundingMode"/>
+			<where>property = 'cashier.roundingMode'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.roundToNearest"/>
+			<where>property = 'cashier.roundToNearest'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.roundingItemId"/>
+			<where>property = 'cashier.roundingItemId'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.roundingItemUuid"/>
+			<where>property = 'cashier.roundingItemUuid'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.roundingDeptId"/>
+			<where>property = 'cashier.roundingDeptId'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.adjustmentReasonField"/>
+			<where>property = 'cashier.adjustmentReasonField'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.allowBillAdjustments"/>
+			<where>property = 'cashier.allowBillAdjustments'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.autofillPaymentAmount"/>
+			<where>property = 'cashier.autofillPaymentAmount'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.patientDashboard2BillCount"/>
+			<where>property = 'cashier.patientDashboard2BillCount'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.reports.departmentCollections"/>
+			<where>property = 'cashier.reports.departmentCollections'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.reports.departmentRevenue"/>
+			<where>property = 'cashier.reports.departmentRevenue'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.reports.shiftSummary"/>
+			<where>property = 'cashier.reports.shiftSummary'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.reports.dailyShiftSummary"/>
+			<where>property = 'cashier.reports.dailyShiftSummary'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.reports.paymentsByPaymentMode"/>
+			<where>property = 'cashier.reports.paymentsByPaymentMode'</where>
+		</update>
+		<update tableName="global_property">
+			<column name="property" value="billing.receipt.logoPath"/>
+			<where>property = 'cashier.receipt.logoPath'</where>
+		</update>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Updated all global property constants in ModuleSettings to use 'billing' prefix instead of 'cashier' to align with the module artifact ID.