### PR TITLE
Fix H2 database configuration in ISequentialReceiptNumberGeneratorServiceTest properties

### DIFF
--- a/api/src/test/java/org/openmrs/module/billing/ISequentialReceiptNumberGeneratorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/ISequentialReceiptNumberGeneratorServiceTest.java
@@ -37,7 +37,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 		Properties properties = super.getRuntimeProperties();
 		
 		// This is needed for proper locking in the in-memory database
-		properties.setProperty(Environment.URL, "jdbc:h2:mem:openmrs;DB_CLOSE_DELAY=30;MVCC=TRUE");
+		properties.setProperty(Environment.URL, "jdbc:h2:mem:openmrs;DB_CLOSE_DELAY=30");
 		
 		return properties;
 	}


### PR DESCRIPTION
Removed the deprecated MVCC setting from the H2 database URL.