### PR TITLE
(fix) O3-5107: Fix Hibernate mapping length for billable service name fields

### DIFF
--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -48,8 +48,8 @@
 		<discriminator column="service_id" insert="false"/>
 
 
-		<property name="name" type="java.lang.String" column="name" not-null="true" length="19"/>
-		<property name="shortName" type="java.lang.String" column="short_name" length="19"/>
+		<property name="name" type="java.lang.String" column="name" not-null="true" length="255"/>
+		<property name="shortName" type="java.lang.String" column="short_name" length="255"/>
 		<many-to-one name="concept" class="org.openmrs.Concept" not-null="false" column="concept_id"/>
 
 		<many-to-one name="serviceType" class="org.openmrs.Concept" not-null="false" column="service_type"/>


### PR DESCRIPTION
This PR fixes the Hibernate mapping length for billable service name fields.  Previously, the Hibernate mapping in `Bill.hbm.xml` incorrectly limited the 'name' and 'short_name' fields to 19 characters, while the database schema (defined in `liquibase.xml`) correctly allowed up to 255 characters.

This mismatch caused Hibernate to potentially truncate or reject service names longer than 19 characters, even though the database could store them.

Changes:
- Updated `Bill.hbm.xml` 'name' field length from 19 to 255
- Updated `Bill.hbm.xml` 'short_name' field length from 19 to 255

This aligns the ORM mapping with the actual database schema, allowing billable services to use their full 255-character capacity for naming.

Ticket: [O3-5107](https://openmrs.atlassian.net/browse/O3-5107)

[O3-5107]: https://openmrs.atlassian.net/browse/O3-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ