### PR TITLE
Update branding from OpenHMIS to OpenMRS

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,8 +9,8 @@
 
 	<artifactId>billing-api</artifactId>
 	<packaging>jar</packaging>
-	<name>OpenMrs Billing Module API</name>
-	<description>API project for the OpenHMIS Billing module</description>
+	<name>OpenMRS Billing Module API</name>
+	<description>API project for the OpenMRS Billing module</description>
 
 	<dependencies>
 		<!-- Begin OpenMRS core -->

--- a/api/src/main/java/org/openmrs/module/billing/BillingModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/billing/BillingModuleActivator.java
@@ -33,7 +33,7 @@ public class BillingModuleActivator extends BaseModuleActivator {
 	 */
 	@Override
 	public void contextRefreshed() {
-		LOG.info("OpenHMIS Billing Module Module refreshed");
+		LOG.info("OpenMRS Billing Module refreshed");
 	}
 	
 	/**
@@ -43,7 +43,7 @@ public class BillingModuleActivator extends BaseModuleActivator {
 	public void started() {
 		//		RoundingUtil.setupRoundingDeptAndItem(LOG);
 		
-		LOG.info("OpenHMIS Billing Module Module started");
+		LOG.info("OpenMRS Billing Module started");
 	}
 	
 	/**
@@ -54,6 +54,6 @@ public class BillingModuleActivator extends BaseModuleActivator {
 		Module module = ModuleFactory.getModuleById(CashierWebConstants.OPENHMIS_CASHIER_MODULE_ID);
 		WebModuleUtil.unloadFilters(module);
 		
-		LOG.info("OpenHMIS Billing Module Module stopped");
+		LOG.info("OpenMRS Billing Module stopped");
 	}
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,4 +1,4 @@
-openhmis.cashier.title=OpenHMIS Cashier Module
+openhmis.cashier.title=OpenMRS Billing Module
 openhmis.cashier.error.nameRequired=A name is required
 openhmis.cashier.error.fieldRequired=This is a required field.
 openhmis.cashier.general.showing=Showing

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -9,8 +9,8 @@
 
 	<artifactId>billing-omod</artifactId>
 	<packaging>jar</packaging>
-	<name>OpenHMIS Billing Module OMOD</name>
-	<description>OMOD project for the OpenHMIS Billing module</description>
+	<name>OpenMRS Billing Module OMOD</name>
+	<description>OMOD project for the OpenMRS Billing module</description>
 
 	<dependencies>
 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -7,7 +7,7 @@
 	<name>${project.parent.name}</name>
 	<version>${project.parent.version}</version>
 	<package>${project.parent.groupId}.${project.parent.artifactId}</package>
-	<author>OpenHMIS</author>
+	<author>OpenMRS</author>
 	<description>
 		${project.parent.description}
 	</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 	<artifactId>billing</artifactId>
 	<version>1.3.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<name>OpenHMIS Billing Module</name>
+	<name>OpenMRS Billing Module</name>
 	<description>Module to provide basic billing functionality</description>
-	<url>https://github.com/OpenHMIS/OpenHMIS/wiki</url>
+	<url>https://github.com/openmrs/openmrs-module-billing</url>
 
 	<distributionManagement>
 		<repository>
@@ -25,7 +25,7 @@
 
 	<developers>
 		<developer>
-			<name>OpenHMIS</name>
+			<name>OpenMRS</name>
 		</developer>
 	</developers>
 
@@ -407,8 +407,8 @@
 			<url>https://openmrs.jfrog.io/openmrs/public</url>
 		</repository>
 		<repository>
-			<id>openhmis-repo</id>
-			<name>OpenHMIS Nexus Repository</name>
+			<id>openmrs-repo-snapshots</id>
+			<name>OpenMRS Snapshots Repository</name>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
Update user-facing display names, documentation, and metadata to reflect OpenMRS branding throughout the module. This includes:

- Module display names in POM files
- Author and developer credits
- GitHub repository URL
- Log messages
- UI title in message properties
- Maven repository labels

No functional changes. All technical identifiers (module ID, extension points, database tables, property keys) remain unchanged to maintain backward compatibility with existing installations.