### PR TITLE
Force clean build on deploy's checkout task in Bamboo

### DIFF
--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -42,7 +42,7 @@ Deploy to Maven:
   key: DTM
   tasks:
   - checkout:
-      force-clean-build: false
+      force-clean-build: true
       description: Checkout default repository
   - script:
       interpreter: SHELL


### PR DESCRIPTION
This will resolve issues with, not being able to checkout the project because an existing one from previous build.