### PR TITLE
O3-5145: Add uniqueness constraints for billable service fields

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillableServiceDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillableServiceDAOImpl.java
@@ -94,6 +94,11 @@ public class HibernateBillableServiceDAOImpl implements BillableServiceDAO {
 			predicates.add(cb.like(cb.lower(root.get("name")), "%" + billableServiceSearch.getName().toLowerCase() + "%"));
 		}
 		
+		if (StringUtils.isNotEmpty(billableServiceSearch.getShortName())) {
+			predicates.add(
+			    cb.like(cb.lower(root.get("shortName")), "%" + billableServiceSearch.getShortName().toLowerCase() + "%"));
+		}
+		
 		if (!billableServiceSearch.getIncludeRetired()) {
 			predicates.add(cb.equal(root.get("retired"), false));
 		}

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillableServiceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillableServiceServiceImpl.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Collections;
 import java.util.List;
 
+import org.openmrs.validator.ValidateUtil;
+
 public class BillableServiceServiceImpl extends BaseOpenmrsService implements BillableServiceService {
 	
 	@Setter(onMethod_ = { @Autowired })
@@ -59,6 +61,7 @@ public class BillableServiceServiceImpl extends BaseOpenmrsService implements Bi
 		if (billableService == null) {
 			throw new NullPointerException("The billableService must be defined.");
 		}
+		ValidateUtil.validate(billableService);
 		return billableServiceDAO.saveBillableService(billableService);
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillableService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillableService.java
@@ -23,7 +23,7 @@ public class BillableService extends BaseChangeableOpenmrsMetadata {
 	
 	public static final long serialVersionUID = 0L;
 	
-	private int billableServiceId;
+	private Integer billableServiceId;
 	
 	private String name;
 	
@@ -39,11 +39,11 @@ public class BillableService extends BaseChangeableOpenmrsMetadata {
 	
 	private BillableServiceStatus serviceStatus = BillableServiceStatus.ENABLED;
 	
-	public int getBillableServiceId() {
+	public Integer getBillableServiceId() {
 		return billableServiceId;
 	}
 	
-	public void setBillableServiceId(int billableServiceId) {
+	public void setBillableServiceId(Integer billableServiceId) {
 		this.billableServiceId = billableServiceId;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/search/BillableServiceSearch.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/search/BillableServiceSearch.java
@@ -37,6 +37,8 @@ public class BillableServiceSearch {
 	
 	private String name;
 	
+	private String shortName;
+	
 	private Boolean includeRetired = false;
 	
 }

--- a/api/src/main/java/org/openmrs/module/billing/validator/BillableServiceValidator.java
+++ b/api/src/main/java/org/openmrs/module/billing/validator/BillableServiceValidator.java
@@ -1,0 +1,66 @@
+package org.openmrs.module.billing.validator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.BillableServiceService;
+import org.openmrs.module.billing.api.model.BillableService;
+import org.openmrs.module.billing.api.search.BillableServiceSearch;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import java.util.List;
+
+@Handler(supports = { BillableService.class }, order = 50)
+public class BillableServiceValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return BillableService.class.isAssignableFrom(clazz);
+	}
+	
+	@Override
+	public void validate(Object target, Errors errors) {
+		if (!(target instanceof BillableService)) {
+			return;
+		}
+		
+		BillableService billableService = (BillableService) target;
+		BillableServiceService service = Context.getService(BillableServiceService.class);
+		
+		// Validate Name Uniqueness
+		if (StringUtils.isNotBlank(billableService.getName())) {
+			BillableServiceSearch search = new BillableServiceSearch();
+			search.setName(billableService.getName());
+			search.setIncludeRetired(false);
+			
+			List<BillableService> existingServices = service.getBillableServices(search, null);
+			
+			for (BillableService existing : existingServices) {
+				if (!existing.getId().equals(billableService.getId())
+				        && existing.getName().equalsIgnoreCase(billableService.getName())) {
+					errors.rejectValue("name", "billing.error.name.duplicate", "The name you have entered already exists");
+					break;
+				}
+			}
+		}
+		
+		// Validate Short Name Uniqueness
+		if (StringUtils.isNotBlank(billableService.getShortName())) {
+			BillableServiceSearch search = new BillableServiceSearch();
+			search.setShortName(billableService.getShortName());
+			search.setIncludeRetired(false);
+			
+			List<BillableService> existingServices = service.getBillableServices(search, null);
+			
+			for (BillableService existing : existingServices) {
+				if (!existing.getId().equals(billableService.getId())
+				        && existing.getShortName().equalsIgnoreCase(billableService.getShortName())) {
+					errors.rejectValue("shortName", "billing.error.shortName.duplicate",
+					    "The short name you have entered already exists");
+					break;
+				}
+			}
+		}
+	}
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -243,3 +243,5 @@ openhmis.cashier.report.generate.excel=As Excel
 openhmis.cashier.report.generate.pdf=As PDF
 openhmis.cashier.report.error.beginAndEndDate=You must select a begin and end date to generate the report.
 openhmis.cashier.report.error.selectReport=You must select a report.
+billing.error.name.duplicate=The name you have entered already exists
+billing.error.shortName.duplicate=The short name you have entered already exists

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -247,6 +247,7 @@
 	</bean>
 
 	<bean id="billValidator" class="org.openmrs.module.billing.validator.BillValidator"/>
+	<bean id="billableServiceValidator" class="org.openmrs.module.billing.validator.BillableServiceValidator"/>
 
 	<bean id="ruleEngine"
 		  class="org.openmrs.module.billing.api.evaluator.ExemptionRuleEngine">

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillableServiceServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillableServiceServiceImplTest.java
@@ -34,20 +34,20 @@ import org.openmrs.module.billing.api.search.BillableServiceSearch;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
 public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTest {
-
+	
 	private BillableServiceService billableServiceService;
-
+	
 	private ConceptService conceptService;
-
+	
 	@BeforeEach
 	public void setup() {
 		billableServiceService = Context.getService(BillableServiceService.class);
 		conceptService = Context.getConceptService();
-
+		
 		executeDataSet(TestConstants.CORE_DATASET2);
 		executeDataSet(TestConstants.BASE_DATASET_DIR + "BillableServiceTest.xml");
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -55,7 +55,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void saveBillableService_shouldThrowNullPointerExceptionIfBillableServiceIsNull() {
 		assertThrows(NullPointerException.class, () -> billableServiceService.saveBillableService(null));
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -66,7 +66,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		assertEquals(0, service.getId());
 		assertEquals("General Consultation", service.getName());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -75,7 +75,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(999);
 		assertNull(service);
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -84,7 +84,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(null);
 		assertNull(service);
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -93,13 +93,13 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(0);
 		assertNotNull(service);
 		String uuid = service.getUuid();
-
+		
 		BillableService foundService = billableServiceService.getBillableServiceByUuid(uuid);
 		assertNotNull(foundService);
 		assertEquals(uuid, foundService.getUuid());
 		assertEquals(0, foundService.getId());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -108,7 +108,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableServiceByUuid("nonexistent-uuid");
 		assertNull(service);
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -117,7 +117,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableServiceByUuid("");
 		assertNull(service);
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -126,11 +126,11 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		Concept concept = conceptService.getConcept(1002);
 		Concept serviceType = conceptService.getConcept(1000);
 		Concept serviceCategory = conceptService.getConcept(1001);
-
+		
 		assertNotNull(concept);
 		assertNotNull(serviceType);
 		assertNotNull(serviceCategory);
-
+		
 		BillableService newService = new BillableService();
 		newService.setName("New Test Service");
 		newService.setShortName("New Test");
@@ -139,19 +139,19 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		newService.setServiceCategory(serviceCategory);
 		newService.setServiceStatus(BillableServiceStatus.ENABLED);
 		newService.setUuid(UUID.randomUUID().toString());
-
+		
 		BillableService savedService = billableServiceService.saveBillableService(newService);
-
+		
 		assertNotNull(savedService);
 		assertNotNull(savedService.getId());
 		assertEquals("New Test Service", savedService.getName());
 		assertEquals(BillableServiceStatus.ENABLED, savedService.getServiceStatus());
-
+		
 		BillableService retrievedService = billableServiceService.getBillableService(savedService.getId());
 		assertNotNull(retrievedService);
 		assertEquals("New Test Service", retrievedService.getName());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -159,16 +159,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void saveBillableService_shouldUpdateExistingBillableService() {
 		BillableService existingService = billableServiceService.getBillableService(1);
 		assertNotNull(existingService);
-
+		
 		String newName = "Updated Specialist Consultation";
 		existingService.setName(newName);
-
+		
 		billableServiceService.saveBillableService(existingService);
-
+		
 		BillableService updatedService = billableServiceService.getBillableService(1);
 		assertEquals(newName, updatedService.getName());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -176,11 +176,11 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldReturnAllBillableServicesWhenSearchIsEmpty() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
-
+		
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -190,7 +190,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		assertNotNull(services);
 		assertTrue(services.isEmpty());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -198,16 +198,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByServiceStatus() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setServiceStatus(BillableServiceStatus.DISABLED);
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-
+		
 		for (BillableService service : services) {
 			assertEquals(BillableServiceStatus.DISABLED, service.getServiceStatus());
 		}
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -215,19 +215,19 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByServiceTypeUuid() {
 		Concept serviceType = conceptService.getConcept(1000);
 		assertNotNull(serviceType);
-
+		
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setServiceTypeUuid(serviceType.getUuid());
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-
+		
 		for (BillableService service : services) {
 			assertEquals(serviceType.getUuid(), service.getServiceType().getUuid());
 		}
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -235,16 +235,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByName() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setName("consultation");
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-
+		
 		for (BillableService service : services) {
 			assertTrue(service.getName().toLowerCase().contains("consultation"));
 		}
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -252,15 +252,15 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldExcludeRetiredServicesByDefault() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setIncludeRetired(false);
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
-
+		
 		for (BillableService service : services) {
 			assertFalse(service.getRetired());
 		}
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -268,12 +268,12 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldReturnEmptyListWhenSearchReturnsNoResults() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setName("NonexistentService");
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertTrue(services.isEmpty());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -281,13 +281,13 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldApplyPagingCorrectly() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		PagingInfo pagingInfo = new PagingInfo(1, 2);
-
+		
 		List<BillableService> services = billableServiceService.getBillableServices(search, pagingInfo);
 		assertNotNull(services);
 		assertTrue(services.size() <= 2);
 		assertNotNull(pagingInfo.getTotalRecordCount());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#purgeBillableService(BillableService)
 	 */
@@ -295,7 +295,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void purgeBillableService_shouldThrowNullPointerExceptionIfBillableServiceIsNull() {
 		assertThrows(NullPointerException.class, () -> billableServiceService.purgeBillableService(null));
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#purgeBillableService(BillableService)
 	 */
@@ -304,7 +304,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		Concept concept = conceptService.getConcept(1002);
 		Concept serviceType = conceptService.getConcept(1000);
 		Concept serviceCategory = conceptService.getConcept(1001);
-
+		
 		BillableService newService = new BillableService();
 		newService.setName("Service To Delete");
 		newService.setShortName("ToDelete");
@@ -313,18 +313,18 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		newService.setServiceCategory(serviceCategory);
 		newService.setServiceStatus(BillableServiceStatus.ENABLED);
 		newService.setUuid(UUID.randomUUID().toString());
-
+		
 		BillableService savedService = billableServiceService.saveBillableService(newService);
-
+		
 		Integer serviceId = savedService.getId();
 		assertNotNull(serviceId);
-
+		
 		billableServiceService.purgeBillableService(savedService);
-
+		
 		BillableService deletedService = billableServiceService.getBillableService(serviceId);
 		assertNull(deletedService);
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#retireBillableService(BillableService, String)
 	 */
@@ -333,24 +333,24 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(0);
 		assertNotNull(service);
 		assertFalse(service.getRetired());
-
+		
 		String retireReason = "No longer in use";
 		BillableService retiredService = billableServiceService.retireBillableService(service, retireReason);
-
+		
 		assertTrue(retiredService.getRetired());
 		assertEquals(retireReason, retiredService.getRetireReason());
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#retireBillableService(BillableService, String)
 	 */
 	@Test
 	public void retireBillableService_shouldThrowExceptionIfReasonIsEmpty() {
 		BillableService service = billableServiceService.getBillableService(0);
-
+		
 		assertThrows(IllegalArgumentException.class, () -> billableServiceService.retireBillableService(service, ""));
 	}
-
+	
 	/**
 	 * @see BillableServiceServiceImpl#unretireBillableService(BillableService)
 	 */
@@ -359,9 +359,9 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(3);
 		assertNotNull(service);
 		assertTrue(service.getRetired());
-
+		
 		BillableService unretiredService = billableServiceService.unretireBillableService(service);
-
+		
 		assertFalse(unretiredService.getRetired());
 		assertNull(unretiredService.getRetireReason());
 	}

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillableServiceServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillableServiceServiceImplTest.java
@@ -34,20 +34,20 @@ import org.openmrs.module.billing.api.search.BillableServiceSearch;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
 public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTest {
-	
+
 	private BillableServiceService billableServiceService;
-	
+
 	private ConceptService conceptService;
-	
+
 	@BeforeEach
 	public void setup() {
 		billableServiceService = Context.getService(BillableServiceService.class);
 		conceptService = Context.getConceptService();
-		
+
 		executeDataSet(TestConstants.CORE_DATASET2);
 		executeDataSet(TestConstants.BASE_DATASET_DIR + "BillableServiceTest.xml");
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -55,7 +55,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void saveBillableService_shouldThrowNullPointerExceptionIfBillableServiceIsNull() {
 		assertThrows(NullPointerException.class, () -> billableServiceService.saveBillableService(null));
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -66,7 +66,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		assertEquals(0, service.getId());
 		assertEquals("General Consultation", service.getName());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -75,7 +75,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(999);
 		assertNull(service);
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableService(Integer)
 	 */
@@ -84,7 +84,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(null);
 		assertNull(service);
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -93,13 +93,13 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(0);
 		assertNotNull(service);
 		String uuid = service.getUuid();
-		
+
 		BillableService foundService = billableServiceService.getBillableServiceByUuid(uuid);
 		assertNotNull(foundService);
 		assertEquals(uuid, foundService.getUuid());
 		assertEquals(0, foundService.getId());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -108,7 +108,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableServiceByUuid("nonexistent-uuid");
 		assertNull(service);
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServiceByUuid(String)
 	 */
@@ -117,7 +117,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableServiceByUuid("");
 		assertNull(service);
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -126,11 +126,11 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		Concept concept = conceptService.getConcept(1002);
 		Concept serviceType = conceptService.getConcept(1000);
 		Concept serviceCategory = conceptService.getConcept(1001);
-		
+
 		assertNotNull(concept);
 		assertNotNull(serviceType);
 		assertNotNull(serviceCategory);
-		
+
 		BillableService newService = new BillableService();
 		newService.setName("New Test Service");
 		newService.setShortName("New Test");
@@ -139,19 +139,19 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		newService.setServiceCategory(serviceCategory);
 		newService.setServiceStatus(BillableServiceStatus.ENABLED);
 		newService.setUuid(UUID.randomUUID().toString());
-		
+
 		BillableService savedService = billableServiceService.saveBillableService(newService);
-		
+
 		assertNotNull(savedService);
 		assertNotNull(savedService.getId());
 		assertEquals("New Test Service", savedService.getName());
 		assertEquals(BillableServiceStatus.ENABLED, savedService.getServiceStatus());
-		
+
 		BillableService retrievedService = billableServiceService.getBillableService(savedService.getId());
 		assertNotNull(retrievedService);
 		assertEquals("New Test Service", retrievedService.getName());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#saveBillableService(BillableService)
 	 */
@@ -159,16 +159,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void saveBillableService_shouldUpdateExistingBillableService() {
 		BillableService existingService = billableServiceService.getBillableService(1);
 		assertNotNull(existingService);
-		
+
 		String newName = "Updated Specialist Consultation";
 		existingService.setName(newName);
-		
+
 		billableServiceService.saveBillableService(existingService);
-		
+
 		BillableService updatedService = billableServiceService.getBillableService(1);
 		assertEquals(newName, updatedService.getName());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -176,11 +176,11 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldReturnAllBillableServicesWhenSearchIsEmpty() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
-		
+
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -190,7 +190,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		assertNotNull(services);
 		assertTrue(services.isEmpty());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -198,16 +198,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByServiceStatus() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setServiceStatus(BillableServiceStatus.DISABLED);
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-		
+
 		for (BillableService service : services) {
 			assertEquals(BillableServiceStatus.DISABLED, service.getServiceStatus());
 		}
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -215,19 +215,19 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByServiceTypeUuid() {
 		Concept serviceType = conceptService.getConcept(1000);
 		assertNotNull(serviceType);
-		
+
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setServiceTypeUuid(serviceType.getUuid());
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-		
+
 		for (BillableService service : services) {
 			assertEquals(serviceType.getUuid(), service.getServiceType().getUuid());
 		}
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -235,16 +235,16 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldFilterByName() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setName("consultation");
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertFalse(services.isEmpty());
-		
+
 		for (BillableService service : services) {
 			assertTrue(service.getName().toLowerCase().contains("consultation"));
 		}
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -252,15 +252,15 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldExcludeRetiredServicesByDefault() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setIncludeRetired(false);
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
-		
+
 		for (BillableService service : services) {
 			assertFalse(service.getRetired());
 		}
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -268,12 +268,12 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldReturnEmptyListWhenSearchReturnsNoResults() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		search.setName("NonexistentService");
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, null);
 		assertNotNull(services);
 		assertTrue(services.isEmpty());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#getBillableServices(BillableServiceSearch, PagingInfo)
 	 */
@@ -281,13 +281,13 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void getBillableServices_shouldApplyPagingCorrectly() {
 		BillableServiceSearch search = new BillableServiceSearch();
 		PagingInfo pagingInfo = new PagingInfo(1, 2);
-		
+
 		List<BillableService> services = billableServiceService.getBillableServices(search, pagingInfo);
 		assertNotNull(services);
 		assertTrue(services.size() <= 2);
 		assertNotNull(pagingInfo.getTotalRecordCount());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#purgeBillableService(BillableService)
 	 */
@@ -295,7 +295,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 	public void purgeBillableService_shouldThrowNullPointerExceptionIfBillableServiceIsNull() {
 		assertThrows(NullPointerException.class, () -> billableServiceService.purgeBillableService(null));
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#purgeBillableService(BillableService)
 	 */
@@ -304,7 +304,7 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		Concept concept = conceptService.getConcept(1002);
 		Concept serviceType = conceptService.getConcept(1000);
 		Concept serviceCategory = conceptService.getConcept(1001);
-		
+
 		BillableService newService = new BillableService();
 		newService.setName("Service To Delete");
 		newService.setShortName("ToDelete");
@@ -313,18 +313,18 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		newService.setServiceCategory(serviceCategory);
 		newService.setServiceStatus(BillableServiceStatus.ENABLED);
 		newService.setUuid(UUID.randomUUID().toString());
-		
+
 		BillableService savedService = billableServiceService.saveBillableService(newService);
-		
+
 		Integer serviceId = savedService.getId();
 		assertNotNull(serviceId);
-		
+
 		billableServiceService.purgeBillableService(savedService);
-		
+
 		BillableService deletedService = billableServiceService.getBillableService(serviceId);
 		assertNull(deletedService);
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#retireBillableService(BillableService, String)
 	 */
@@ -333,24 +333,24 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(0);
 		assertNotNull(service);
 		assertFalse(service.getRetired());
-		
+
 		String retireReason = "No longer in use";
 		BillableService retiredService = billableServiceService.retireBillableService(service, retireReason);
-		
+
 		assertTrue(retiredService.getRetired());
 		assertEquals(retireReason, retiredService.getRetireReason());
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#retireBillableService(BillableService, String)
 	 */
 	@Test
 	public void retireBillableService_shouldThrowExceptionIfReasonIsEmpty() {
 		BillableService service = billableServiceService.getBillableService(0);
-		
+
 		assertThrows(IllegalArgumentException.class, () -> billableServiceService.retireBillableService(service, ""));
 	}
-	
+
 	/**
 	 * @see BillableServiceServiceImpl#unretireBillableService(BillableService)
 	 */
@@ -359,10 +359,34 @@ public class BillableServiceServiceImplTest extends BaseModuleContextSensitiveTe
 		BillableService service = billableServiceService.getBillableService(3);
 		assertNotNull(service);
 		assertTrue(service.getRetired());
-		
+
 		BillableService unretiredService = billableServiceService.unretireBillableService(service);
-		
+
 		assertFalse(unretiredService.getRetired());
 		assertNull(unretiredService.getRetireReason());
+	}
+
+	@Test
+	public void saveBillableService_shouldFailIfNameExists() {
+		Concept concept = conceptService.getConcept(1002);
+		BillableService newService = new BillableService();
+		newService.setName("General Consultation");
+		newService.setShortName("Unique Short");
+		newService.setConcept(concept);
+		newService.setServiceStatus(BillableServiceStatus.ENABLED);
+
+		assertThrows(org.openmrs.api.APIException.class, () -> billableServiceService.saveBillableService(newService));
+	}
+
+	@Test
+	public void saveBillableService_shouldFailIfShortNameExists() {
+		Concept concept = conceptService.getConcept(1002);
+		BillableService newService = new BillableService();
+		newService.setName("Unique Name");
+		newService.setShortName("Gen Consult");
+		newService.setConcept(concept);
+		newService.setServiceStatus(BillableServiceStatus.ENABLED);
+
+		assertThrows(org.openmrs.api.APIException.class, () -> billableServiceService.saveBillableService(newService));
 	}
 }


### PR DESCRIPTION
## Summary
This PR implements server-side validation to ensure the uniqueness of `BillableService` names and short names. Previously, it was possible to create duplicate services, leading to data integrity issues.

### Changes
- Validator: Added `BillableServiceValidator` to reject duplicate names and short names (case-insensitive).
- Model Fix: Changed `BillableService.billableServiceId` from `int` to `Integer` to correctly distinguish between new (null ID) and existing (ID 0) services during validation.
- DAO: Enhanced `HibernateBillableServiceDAO` and `BillableServiceSearch` to support filtering by `shortName` for efficient validation.
- Tests: Added regression tests to `BillableServiceServiceImplTest` to verify the new constraints.

## Related Issue
[O3-5145](https://openmrs.atlassian.net/browse/O3-5145)

[O3-5145]: https://openmrs.atlassian.net/browse/O3-5145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ