### PR TITLE
O3-5156: Fix Biling itemList update functionality

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
@@ -161,6 +161,7 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 			} else {
 				billToUpdate.setStatus(BillStatus.PENDING);
 			}
+            
 			// Save the updated bill
 			return super.save(billToUpdate);
 		}

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
@@ -149,34 +149,4 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 	public void setOrder(Order order) {
 		this.order = order;
 	}
-	
-	/**
-	 * Compares line items for equality based on UUID only. Two items are equal only if they have the
-	 * same UUID.
-	 */
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
-		
-		BillLineItem other = (BillLineItem) obj;
-		
-		// Only compare by UUID - both must have UUIDs and they must match
-		String thisUuid = this.getUuid();
-		String otherUuid = other.getUuid();
-		
-		if (thisUuid == null || otherUuid == null) {
-			return false;
-		}
-		
-		return thisUuid.equals(otherUuid);
-	}
-	
-	public int hashCode() {
-		return Objects.hash(getUuid(), getId(), getBill(), getItem(), getBillableService(), getPrice(), getQuantity(),
-		    getLineItemOrder());
-	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -224,10 +224,13 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BigDecimal updatedPrice = firstItem.getPrice().add(BigDecimal.TEN);
 		firstItem.setPrice(updatedPrice);
 		
-		Bill updatedBill = billService.save(pendingBill);
+		billService.save(pendingBill);
 		Context.flushSession();
+        Context.clearSession();
+
+        Bill updatedBill = billService.getById(2);
 		
-		assertSame(pendingBill, updatedBill);
+		assertEquals(pendingBill, updatedBill);
 		assertEquals(updatedPrice, updatedBill.getLineItems().get(0).getPrice());
 	}
 	


### PR DESCRIPTION
This PR is raised to Fix the error occurring while updating the LineItems:

Error Image:

<img width="1500" height="809" alt="image" src="https://github.com/user-attachments/assets/7797dba7-958a-4dda-8e0d-e0e688a023ea" />

Error message:

```
{
    "error": {
        "message": "[null]",
        "code": "java.util.ArrayList$Itr:1095",
        "detail": "java.util.ConcurrentModificationException\n\tat java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1095)\n\tat java.base/java.util.ArrayList$Itr.next(ArrayList.java:1049)\n\tat org.hibernate.collection.internal.AbstractPersistentCollection$IteratorProxy.next(AbstractPersistentCollection.java:893)\n\tat org.openmrs.module.billing.api.impl.BillServiceImpl.save(BillServiceImpl.java:141)\n\tat org.openmrs.module.billing.api.impl.BillServiceImpl.save(BillServiceImpl.java:79)\n\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat  ....
    }
}
```

### Why its happening?

When the user tries to update a Line Item , in the `BillServiceImpl.java` the code start comparing and updating the same object leading to a ConcurrentModificationException. 

### What does the changes do?

The changes make sure that if the items are the same ( same memory address are not added creating duplicates ) but at the same time during creating a new Line Item its added.