### PR TITLE
O3-5197: Add cashier field to Payment entity

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.billing.api.model;
 
+import org.openmrs.User;
 import org.openmrs.module.billing.api.base.entity.model.BaseInstanceCustomizableData;
 
 import java.math.BigDecimal;
@@ -27,6 +28,8 @@ public class Payment extends BaseInstanceCustomizableData<PaymentMode, PaymentAt
 	private Integer paymentId;
 	
 	private Bill bill;
+	
+	private User cashier;
 	
 	private BigDecimal amount;
 	
@@ -79,5 +82,13 @@ public class Payment extends BaseInstanceCustomizableData<PaymentMode, PaymentAt
 	
 	public void setBill(Bill bill) {
 		this.bill = bill;
+	}
+	
+	public User getCashier() {
+		return cashier;
+	}
+	
+	public void setCashier(User cashier) {
+		this.cashier = cashier;
 	}
 }

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -194,6 +194,7 @@
 		<many-to-one name="bill" class="org.openmrs.module.billing.api.model.Bill" column="bill_id" not-null="true"/>
 		<many-to-one name="instanceType" class="org.openmrs.module.billing.api.model.PaymentMode"
 		             column="payment_mode_id" not-null="true"/>
+		<many-to-one name="cashier" class="org.openmrs.User" column="cashier_id" not-null="true"/>
 
 		<property name="amount" type="java.math.BigDecimal" column="amount" not-null="true"/>
 		<property name="amountTendered" type="java.math.BigDecimal" column="amount_tendered" not-null="true"/>

--- a/api/src/test/java/org/openmrs/module/billing/api/model/PaymentTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/model/PaymentTest.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.billing.api.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.User;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.math.BigDecimal;
+
+/**
+ * Tests for {@link Payment}.
+ */
+public class PaymentTest extends BaseModuleContextSensitiveTest {
+	
+	/**
+	 * @verifies set and get cashier correctly
+	 * @see Payment#setCashier(User)
+	 * @see Payment#getCashier()
+	 */
+	@Test
+	public void setCashier_shouldSetAndGetCashierCorrectly() throws Exception {
+		Payment payment = new Payment();
+		User cashier = new User();
+		cashier.setUserId(1);
+		cashier.setUsername("admin");
+		
+		payment.setCashier(cashier);
+		
+		Assert.assertNotNull(payment.getCashier());
+		Assert.assertEquals(cashier, payment.getCashier());
+		Assert.assertEquals("admin", payment.getCashier().getUsername());
+	}
+	
+	/**
+	 * @verifies allow null cashier initially
+	 * @see Payment#getCashier()
+	 */
+	@Test
+	public void getCashier_shouldAllowNullCashierInitially() throws Exception {
+		Payment payment = new Payment();
+		
+		Assert.assertNull(payment.getCashier());
+	}
+	
+	/**
+	 * @verifies maintain payment amount when cashier is set
+	 * @see Payment#setCashier(User)
+	 */
+	@Test
+	public void setCashier_shouldMaintainPaymentAmountWhenCashierIsSet() throws Exception {
+		Payment payment = new Payment();
+		BigDecimal amount = new BigDecimal("100.50");
+		payment.setAmount(amount);
+		
+		User cashier = new User();
+		cashier.setUserId(2);
+		payment.setCashier(cashier);
+		
+		Assert.assertEquals(amount, payment.getAmount());
+		Assert.assertEquals(cashier, payment.getCashier());
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.billing.web.rest.resource;
 
+import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.web.base.resource.BaseRestDataResource;
 import org.openmrs.module.billing.api.IBillService;
@@ -55,6 +56,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
             description.addProperty("attributes");
             description.addProperty("amount");
             description.addProperty("amountTendered");
+            description.addProperty("cashier", Representation.REF);
             description.addProperty("dateCreated");
             description.addProperty("voided");
         }
@@ -69,6 +71,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
         description.addProperty("attributes");
         description.addProperty("amount");
         description.addProperty("amountTendered");
+        description.addProperty("cashier");
 
         return description;
     }
@@ -124,6 +127,17 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
         }
     }
 
+    @PropertySetter("cashier")
+    public void setCashier(Payment instance, String uuid) {
+        if (uuid != null) {
+            User cashier = Context.getUserService().getUserByUuid(uuid);
+            if (cashier == null) {
+                throw new ObjectNotFoundException();
+            }
+            instance.setCashier(cashier);
+        }
+    }
+
     @PropertyGetter("dateCreated")
     public Long getPaymentDate(Payment instance) {
         return instance.getDateCreated().getTime();
@@ -131,6 +145,11 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 
     @Override
     public Payment save(Payment delegate) {
+        // Auto-assign cashier if not set
+        if (delegate.getCashier() == null) {
+            delegate.setCashier(Context.getAuthenticatedUser());
+        }
+        
         IBillService service = Context.getService(IBillService.class);
         Bill bill = delegate.getBill();
         bill.addPayment(delegate);

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -945,4 +945,34 @@
 			<where>property = 'cashier.receipt.logoPath'</where>
 		</update>
 	</changeSet>
+
+	<changeSet id="openmrs.billing-002-v3.1.0-20251120" author="OpenMRS">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<columnExists tableName="cashier_bill_payment" columnName="cashier_id"/>
+			</not>
+		</preConditions>
+		<comment>Add cashier_id column to cashier_bill_payment table to track which user processed each payment</comment>
+		
+		<addColumn tableName="cashier_bill_payment">
+			<column name="cashier_id" type="int">
+				<constraints nullable="true"/>
+			</column>
+		</addColumn>
+		
+		<addForeignKeyConstraint constraintName="cashier_bill_payment_cashier_fk"
+								 baseTableName="cashier_bill_payment" baseColumnNames="cashier_id"
+								 referencedTableName="users" referencedColumnNames="user_id"/>
+		
+		<createIndex indexName="cashier_bill_payment_cashier_idx" tableName="cashier_bill_payment">
+			<column name="cashier_id"/>
+		</createIndex>
+		
+		<comment>Set cashier_id to creator for existing payments (data migration)</comment>
+		<sql>
+			UPDATE cashier_bill_payment SET cashier_id = creator WHERE cashier_id IS NULL
+		</sql>
+		
+		<addNotNullConstraint tableName="cashier_bill_payment" columnName="cashier_id" columnDataType="int"/>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
- Add cashier (User) field to Payment model
- Add Hibernate mapping for cashier relationship
- Add database migration with foreign key and index
- Add REST API support with auto-assignment
- Add comprehensive unit tests (3 tests, all passing)

This implementation tracks which user processed each payment, enabling payment auditing and cashier-specific reporting.

Fixes: O3-5197