### PR TITLE
O3-5246: Fixing the payments issue Post addition of Pending state check

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
+++ b/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
@@ -209,7 +209,7 @@ public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
 				activeBill.setCashPoint(cashPoints.get(0));
 				activeBill.addLineItem(billLineItem);
 				activeBill.setStatus(BillStatus.PENDING);
-				billService.save(activeBill);
+				billService.saveBill(activeBill);
 			} else {
 				LOG.error("User is not a provider");
 			}

--- a/api/src/main/java/org/openmrs/module/billing/advice/OrderCreationMethodBeforeAdvice.java
+++ b/api/src/main/java/org/openmrs/module/billing/advice/OrderCreationMethodBeforeAdvice.java
@@ -157,7 +157,7 @@ public class OrderCreationMethodBeforeAdvice implements MethodBeforeAdvice {
 				activeBill.setCashPoint(cashPoints.get(0));
 				activeBill.addLineItem(billLineItem);
 				activeBill.setStatus(BillStatus.PENDING);
-				billService.save(activeBill);
+				billService.saveBill(activeBill);
 			}
 			
 		}

--- a/api/src/main/java/org/openmrs/module/billing/api/ItemPriceService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/ItemPriceService.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface ItemPriceService extends IMetadataDataService<CashierItemPrice> {
 	
-	CashierItemPrice save(CashierItemPrice price);
+	CashierItemPrice saveBill(CashierItemPrice price);
 	
 	List<CashierItemPrice> getItemPrice(StockItem stockItem);
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/base/entity/IObjectDataService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/base/entity/IObjectDataService.java
@@ -50,7 +50,7 @@ public interface IObjectDataService<E extends OpenmrsObject> extends OpenmrsServ
 	 * @should update the object successfully
 	 * @should create the object successfully
 	 */
-	E save(E object);
+	E saveBill(E object);
 	
 	/**
 	 * Saves an object to the database along with the specified related {@link OpenmrsObject}'s within a

--- a/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseEntityDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseEntityDataServiceImpl.java
@@ -68,7 +68,7 @@ public abstract class BaseEntityDataServiceImpl<E extends OpenmrsData> extends B
 		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
-			return save(entity);
+			return saveBill(entity);
 		}
 	}
 	
@@ -104,7 +104,7 @@ public abstract class BaseEntityDataServiceImpl<E extends OpenmrsData> extends B
 		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
-			return save(entity);
+			return saveBill(entity);
 		}
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseMetadataDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseMetadataDataServiceImpl.java
@@ -78,7 +78,7 @@ public abstract class BaseMetadataDataServiceImpl<E extends OpenmrsMetadata> ext
 		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
-			return save(entity);
+			return saveBill(entity);
 		}
 	}
 	
@@ -122,7 +122,7 @@ public abstract class BaseMetadataDataServiceImpl<E extends OpenmrsMetadata> ext
 		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
-			return save(entity);
+			return saveBill(entity);
 		}
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseObjectDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/base/entity/impl/BaseObjectDataServiceImpl.java
@@ -102,7 +102,7 @@ public abstract class BaseObjectDataServiceImpl<E extends OpenmrsObject, P exten
 	
 	@Override
 	@Transactional
-	public E save(E object) {
+	public E saveBill(E object) {
 		P privileges = getPrivileges();
 		if (privileges != null && !StringUtils.isEmpty(privileges.getSavePrivilege())) {
 			PrivilegeUtil.requirePrivileges(Context.getAuthenticatedUser(), privileges.getSavePrivilege());

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillLineItemServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillLineItemServiceImpl.java
@@ -107,7 +107,7 @@ public class BillLineItemServiceImpl extends BaseEntityDataServiceImpl<BillLineI
 			bill.synchronizeBillStatus();
 			// Save the bill to persist the collection change
 			IBillService billService = Context.getService(IBillService.class);
-			billService.save(bill);
+			billService.saveBill(bill);
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillServiceImpl.java
@@ -113,7 +113,7 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 	@Override
 	@Authorized({ PrivilegeConstants.MANAGE_BILLS })
 	@Transactional
-	public Bill save(Bill bill) {
+	public Bill saveBill(Bill bill) {
 		if (bill == null) {
 			throw new NullPointerException("The bill must be defined.");
 		}
@@ -161,13 +161,13 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 			} else {
 				billToUpdate.setStatus(BillStatus.PENDING);
 			}
-            
+			
 			// Save the updated bill
-			return super.save(billToUpdate);
+			return super.saveBill(billToUpdate);
 		}
 		
 		// If no pending bill exists, just save the new bill as it is
-		return super.save(bill);
+		return super.saveBill(bill);
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/ItemPriceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/ItemPriceServiceImpl.java
@@ -44,9 +44,9 @@ public class ItemPriceServiceImpl extends BaseMetadataDataServiceImpl<CashierIte
 	}
 	
 	@Override
-	public CashierItemPrice save(CashierItemPrice object) {
+	public CashierItemPrice saveBill(CashierItemPrice object) {
 		LOG.debug("Processing save Price");
-		return super.save(object);
+		return super.saveBill(object);
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
@@ -177,14 +177,6 @@ public class Bill extends BaseOpenmrsData {
 	}
 	
 	public void setLineItems(List<BillLineItem> lineItems) {
-		// Only validate if lineItems is already initialized
-		// This prevents validation during Hibernate entity loading (when lineItems is null)
-		// but still validates user modifications (when lineItems is already set)
-		if (this.lineItems != null && !isPending()) {
-			throw new IllegalStateException(
-			        "Line items can only be modified when the bill is in PENDING state. Current status: "
-			                + this.getStatus());
-		}
 		this.lineItems = lineItems;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
+++ b/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
@@ -1,0 +1,34 @@
+package org.openmrs.module.billing.validator;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.IBillService;
+import org.openmrs.module.billing.api.model.Bill;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Handler(supports = { Bill.class }, order = 50)
+public class BillValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return Bill.class.isAssignableFrom(clazz);
+	}
+	
+	@Override
+	public void validate(Object target, Errors errors) {
+		if (!(target instanceof Bill)) {
+			throw new IllegalArgumentException("error.general and must be of type " + Bill.class);
+		}
+		Bill bill = (Bill) target;
+		if (bill.getId() != null) {
+			Bill existingBill = Context.getService(IBillService.class).getById(bill.getId());
+			if (existingBill != null && !existingBill.isPending()) {
+				errors.reject("billing.bill.notPending",
+				    "Bill can only be modified when the bill is in PENDING state. Current status: "
+				            + existingBill.getStatus());
+			}
+		}
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/module/billing/ICashPointServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/ICashPointServiceTest.java
@@ -105,7 +105,7 @@ public class ICashPointServiceTest extends IMetadataDataServiceTest<ICashPointSe
 		CashPoint cashPoint = service.getById(0);
 		cashPoint.setRetired(true);
 		cashPoint.setRetireReason("reason");
-		service.save(cashPoint);
+		service.saveBill(cashPoint);
 		Location location = Context.getLocationService().getLocation(0);
 		
 		Context.flushSession();
@@ -188,7 +188,7 @@ public class ICashPointServiceTest extends IMetadataDataServiceTest<ICashPointSe
 		CashPoint cashPoint = service.getById(0);
 		cashPoint.setRetired(true);
 		cashPoint.setRetireReason("reason");
-		service.save(cashPoint);
+		service.saveBill(cashPoint);
 		Location location = Context.getLocationService().getLocation(0);
 		
 		Context.flushSession();

--- a/api/src/test/java/org/openmrs/module/billing/ITimesheetServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/ITimesheetServiceTest.java
@@ -123,7 +123,7 @@ public class ITimesheetServiceTest extends IEntityDataServiceTest<ITimesheetServ
 		Timesheet timesheet = createEntity(true);
 		timesheet.setClockOut(null);
 		
-		timesheet = service.save(timesheet);
+		timesheet = service.saveBill(timesheet);
 		Context.flushSession();
 		
 		Timesheet current = service.getCurrentTimesheet(timesheet.getCashier());
@@ -161,7 +161,7 @@ public class ITimesheetServiceTest extends IEntityDataServiceTest<ITimesheetServ
 		timesheet.setCashier(cashier);
 		timesheet.setClockOut(null);
 		
-		service.save(timesheet);
+		service.saveBill(timesheet);
 		Context.flushSession();
 		
 		Timesheet current = service.getCurrentTimesheet(cashier);

--- a/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
@@ -313,15 +313,4 @@ public class BillTest {
 		assertEquals(1, bill.getLineItems().size());
 	}
 	
-	@Test(expected = IllegalStateException.class)
-	public void setLineItems_shouldThrowExceptionWhenBillIsPosted() {
-		Bill bill = new Bill();
-		bill.setId(1);
-		bill.setStatus(BillStatus.POSTED);
-		ArrayList<BillLineItem> existingLineItems = new ArrayList<>();
-		bill.setLineItems(existingLineItems);
-		existingLineItems.add(new BillLineItem());
-		bill.setLineItems(existingLineItems);
-	}
-	
 }

--- a/api/src/test/java/org/openmrs/module/billing/base/entity/IObjectDataServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/base/entity/IObjectDataServiceTest.java
@@ -88,8 +88,8 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	 * @see org.openmrs.module.openhmis.commons.api.entity.IObjectDataService#save(OpenmrsObject)
 	 */
 	@Test(expected = NullPointerException.class)
-	public void save_shouldThrowNullPointerExceptionIfTheObjectIsNull() throws Exception {
-		service.save(null);
+	public void save_Bill_shouldThrowNullPointerExceptionIfTheObjectIsNull() throws Exception {
+		service.saveBill(null);
 	}
 	
 	/**
@@ -97,10 +97,10 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	 * @see org.openmrs.module.openhmis.commons.api.entity.IObjectDataService#save(OpenmrsObject)
 	 */
 	@Test(expected = APIException.class)
-	public void save_shouldValidateTheObjectBeforeSaving() throws Exception {
+	public void save_Bill_shouldValidateTheObjectBeforeSaving() throws Exception {
 		E entity = createEntity(false);
 		
-		service.save(entity);
+		service.saveBill(entity);
 	}
 	
 	/**
@@ -108,10 +108,10 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	 * @see org.openmrs.module.openhmis.commons.api.entity.IObjectDataService#save(OpenmrsObject)
 	 */
 	@Test
-	public void save_shouldReturnSavedObject() throws Exception {
+	public void save_Bill_shouldReturnSavedObject() throws Exception {
 		E entity = createEntity(true);
 		
-		E result = service.save(entity);
+		E result = service.saveBill(entity);
 		Context.flushSession();
 		
 		Assert.assertNotNull(result);
@@ -123,13 +123,13 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	 * @see org.openmrs.module.openhmis.commons.api.entity.IObjectDataService#save(OpenmrsObject)
 	 */
 	@Test
-	public void save_shouldUpdateTheObjectSuccessfully() throws Exception {
+	public void save_Bill_shouldUpdateTheObjectSuccessfully() throws Exception {
 		E entity = service.getById(0);
 		Assert.assertNotNull(entity);
 		
 		updateEntityFields(entity);
 		
-		service.save(entity);
+		service.saveBill(entity);
 		Context.flushSession();
 		
 		E updatedEntity = service.getById(entity.getId());
@@ -141,10 +141,10 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	 * @see org.openmrs.module.openhmis.commons.api.entity.IObjectDataService#save(OpenmrsObject)
 	 */
 	@Test
-	public void save_shouldCreateTheObjectSuccessfully() throws Exception {
+	public void save_Bill_shouldCreateTheObjectSuccessfully() throws Exception {
 		E entity = createEntity(true);
 		
-		entity = service.save(entity);
+		entity = service.saveBill(entity);
 		Context.flushSession();
 		
 		E result = service.getById(entity.getId());
@@ -168,7 +168,7 @@ public abstract class IObjectDataServiceTest<S extends IObjectDataService<E>, E 
 	public void purge_shouldDeleteTheSpecifiedObject() throws Exception {
 		E entity = createEntity(true);
 		
-		service.save(entity);
+		service.saveBill(entity);
 		Context.flushSession();
 		
 		E result = service.getById(entity.getId());

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillLineItemServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillLineItemServiceImplTest.java
@@ -64,7 +64,7 @@ public class BillLineItemServiceImplTest extends BaseModuleContextSensitiveTest 
 		lineItem.setPrice(BigDecimal.valueOf(99.99));
 		
 		// Should not throw exception
-		BillLineItem savedItem = billLineItemService.save(lineItem);
+		BillLineItem savedItem = billLineItemService.saveBill(lineItem);
 		assertNotNull(savedItem);
 		assertEquals(BigDecimal.valueOf(99.99), savedItem.getPrice());
 	}
@@ -87,7 +87,7 @@ public class BillLineItemServiceImplTest extends BaseModuleContextSensitiveTest 
 		lineItem.setPrice(BigDecimal.valueOf(99.99));
 		
 		// Should throw exception
-		assertThrows(IllegalStateException.class, () -> billLineItemService.save(lineItem));
+		assertThrows(IllegalStateException.class, () -> billLineItemService.saveBill(lineItem));
 	}
 	
 	/**
@@ -108,7 +108,7 @@ public class BillLineItemServiceImplTest extends BaseModuleContextSensitiveTest 
 		lineItem.setPrice(BigDecimal.valueOf(99.99));
 		
 		// Should throw exception
-		assertThrows(IllegalStateException.class, () -> billLineItemService.save(lineItem));
+		assertThrows(IllegalStateException.class, () -> billLineItemService.saveBill(lineItem));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -12,7 +12,6 @@
  * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
  */
 
-
 package org.openmrs.module.billing.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -62,11 +61,11 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldThrowNullPointerExceptionIfBillIsNull() {
-		assertThrows(NullPointerException.class, () -> billService.save(null));
+	public void save_Bill_shouldThrowNullPointerExceptionIfBillIsNull() {
+		assertThrows(NullPointerException.class, () -> billService.saveBill(null));
 	}
 	
 	/**
@@ -171,10 +170,10 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldCreateNewBillWithNewItem() {
+	public void save_Bill_shouldCreateNewBillWithNewItem() {
 		Patient patient = patientService.getPatient(1);
 		assertNotNull(patient);
 		
@@ -196,7 +195,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		lineItem.setPaymentStatus(BillStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
-		Bill savedBill = billService.save(newBill);
+		Bill savedBill = billService.saveBill(newBill);
 		Context.flushSession();
 		
 		assertNotNull(savedBill);
@@ -211,10 +210,10 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldUpdateExistingBillWithUpdatedBillItem() {
+	public void save_Bill_shouldUpdateExistingBillWithUpdatedBillItem() {
 		Bill pendingBill = billService.getById(2);
 		assertNotNull(pendingBill);
 		assertEquals(BillStatus.PENDING, pendingBill.getStatus());
@@ -224,11 +223,11 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BigDecimal updatedPrice = firstItem.getPrice().add(BigDecimal.TEN);
 		firstItem.setPrice(updatedPrice);
 		
-		billService.save(pendingBill);
+		billService.saveBill(pendingBill);
 		Context.flushSession();
-        Context.clearSession();
-
-        Bill updatedBill = billService.getById(2);
+		Context.clearSession();
+		
+		Bill updatedBill = billService.getById(2);
 		
 		assertEquals(pendingBill, updatedBill);
 		assertEquals(updatedPrice, updatedBill.getLineItems().get(0).getPrice());
@@ -259,10 +258,10 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldAllowAddingLineItemsToPendingBill() {
+	public void save_Bill_shouldAllowAddingLineItemsToPendingBill() {
 		// Get the PENDING bill from test data (bill_id=2)
 		Bill pendingBill = billService.getById(2);
 		assertNotNull(pendingBill);
@@ -277,16 +276,16 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		pendingBill.addLineItem(newLineItem);
 		
 		// Should not throw exception
-		Bill savedBill = billService.save(pendingBill);
+		Bill savedBill = billService.saveBill(pendingBill);
 		assertNotNull(savedBill);
 		assertTrue(savedBill.getLineItems().size() > 0);
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldThrowExceptionWhenAddingLineItemsToPostedBill() {
+	public void save_Bill_shouldThrowExceptionWhenAddingLineItemsToPostedBill() {
 		// Get the POSTED bill from test data (bill_id=0)
 		Bill postedBill = billService.getById(0);
 		assertNotNull(postedBill);
@@ -302,10 +301,10 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldThrowExceptionWhenAddingLineItemsToPaidBill() {
+	public void save_Bill_shouldThrowExceptionWhenAddingLineItemsToPaidBill() {
 		// Get the PAID bill from test data (bill_id=1)
 		Bill paidBill = billService.getById(1);
 		assertNotNull(paidBill);
@@ -321,10 +320,10 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldAllowRemovingLineItemsFromPendingBill() {
+	public void save_Bill_shouldAllowRemovingLineItemsFromPendingBill() {
 		// Get the PENDING bill from test data (bill_id=2)
 		Bill pendingBill = billService.getById(2);
 		assertNotNull(pendingBill);
@@ -338,16 +337,16 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		pendingBill.removeLineItem(itemToRemove);
 		
 		// Should not throw exception
-		Bill savedBill = billService.save(pendingBill);
+		Bill savedBill = billService.saveBill(pendingBill);
 		assertNotNull(savedBill);
 		assertTrue(savedBill.getLineItems().size() < originalSize);
 	}
 	
 	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#save(Bill)
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void save_shouldThrowExceptionWhenRemovingLineItemsFromPostedBill() {
+	public void save_Bill_shouldThrowExceptionWhenRemovingLineItemsFromPostedBill() {
 		// Get the POSTED bill from test data (bill_id=0)
 		Bill postedBill = billService.getById(0);
 		assertNotNull(postedBill);
@@ -357,5 +356,24 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		
 		// Should throw exception
 		assertThrows(IllegalStateException.class, () -> postedBill.removeLineItem(itemToRemove));
+	}
+	
+	@Test
+	public void save_Bill_shouldNotThrowExceptionForPendingBill() {
+		Bill pendingBill = billService.getById(2);
+		assertNotNull(pendingBill);
+		assertEquals(BillStatus.PENDING, pendingBill.getStatus());
+		pendingBill.setReceiptNumber("ABV");
+		assertDoesNotThrow(() -> billService.saveBill(pendingBill));
+	}
+	
+	@Test
+	public void save_Bill_shouldThrowIllegalStateExceptionForPostedBill() {
+		Bill postedBill = billService.getById(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+		
+		postedBill.setReceiptNumber("ABV");
+		assertThrows(IllegalArgumentException.class, () -> billService.saveBill(postedBill));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+package org.openmrs.module.billing.validator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.TestConstants;
+import org.openmrs.module.billing.api.IBillService;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
+/**
+ * Integration tests for {@link BillValidator}
+ */
+public class BillValidatorTest extends BaseModuleContextSensitiveTest {
+	
+	private BillValidator billValidator;
+	
+	private IBillService billService;
+	
+	@BeforeEach
+	public void setup() throws Exception {
+		billValidator = new BillValidator();
+		billService = Context.getService(IBillService.class);
+		
+		executeDataSet(TestConstants.CORE_DATASET2);
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "StockOperationType.xml");
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "PaymentModeTest.xml");
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "CashPointTest.xml");
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "BillTest.xml");
+	}
+	
+	@Test
+	public void validate_shouldNotRejectPendingBill() {
+		Bill pendingBill = billService.getById(2);
+		assertNotNull(pendingBill);
+		assertEquals(BillStatus.PENDING, pendingBill.getStatus());
+		
+		Errors errors = new BindException(pendingBill, "bill");
+		billValidator.validate(pendingBill, errors);
+		
+		assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldRejectPostedBill() {
+		Bill postedBill = billService.getById(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+		
+		Errors errors = new BindException(postedBill, "bill");
+		billValidator.validate(postedBill, errors);
+		
+		assertTrue(errors.hasErrors());
+		assertTrue(errors.getGlobalError().getDefaultMessage()
+		        .contains("Bill can only be modified when the bill is in PENDING state"));
+		assertTrue(errors.getGlobalError().getDefaultMessage().contains("POSTED"));
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestDataResource.java
@@ -112,7 +112,7 @@ public abstract class BaseRestDataResource<E extends OpenmrsData> extends DataDe
 
     @Override
     public E save(E delegate) {
-        return getService().save(delegate);
+        return getService().saveBill(delegate);
     }
 
     @Override

--- a/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestMetadataResource.java
@@ -66,7 +66,7 @@ public abstract class BaseRestMetadataResource<E extends OpenmrsMetadata> extend
     @Override
     public E save(E entity) {
         try {
-            return getService().save(entity);
+            return getService().saveBill(entity);
         } catch (PrivilegeException p) {
             LOG.error("Exception occured when trying to save entity <" + entity.getName() + "> as privilege is missing", p);
             throw new PrivilegeException("Can't save entity with name <" + entity.getName() + "> as privilege is missing");

--- a/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/base/resource/BaseRestObjectResource.java
@@ -71,7 +71,7 @@ public abstract class BaseRestObjectResource<E extends OpenmrsObject> extends De
         }
 
         IObjectDataService<E> service = Context.getService(clazz);
-        service.save(delegate);
+        service.saveBill(delegate);
 
         return delegate;
     }

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/AbstractSequentialReceiptNumberGenerator.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/AbstractSequentialReceiptNumberGenerator.java
@@ -62,7 +62,7 @@ public abstract class AbstractSequentialReceiptNumberGenerator {
         }
 
         // Save the generator settings
-        getService().save(generator);
+        getService().saveBill(generator);
 
         // Set the system generator
         ReceiptNumberGeneratorFactory.setGenerator(new SequentialReceiptNumberGenerator());

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/CashierController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/CashierController.java
@@ -127,7 +127,7 @@ public class CashierController {
             return null;
         }
 
-        Context.getService(ITimesheetService.class).save(timesheet);
+        Context.getService(ITimesheetService.class).saveBill(timesheet);
 
         if (StringUtils.isEmpty(returnUrl)) {
             returnUrl = "redirect:";

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/filter/CashierLogoutFilter.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/filter/CashierLogoutFilter.java
@@ -81,7 +81,7 @@ public class CashierLogoutFilter implements Filter {
 
         if (cashierIsClockedIn(timesheet)) {
             timesheet.setClockOut(new Date());
-            timesheetService.save(timesheet);
+            timesheetService.saveBill(timesheet);
         }
     }
 

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/controller/CashierRestController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/controller/CashierRestController.java
@@ -35,7 +35,7 @@ public class CashierRestController extends BaseRestController {
         BillableService billableService = request.billableServiceMapper(request);
         IBillableItemsService service = Context.getService(IBillableItemsService.class);
 
-        service.save(billableService);
+        service.saveBill(billableService);
 
         return true;
     }

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
@@ -134,7 +134,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
         IBillService service = Context.getService(IBillService.class);
         Bill bill = delegate.getBill();
         bill.addPayment(delegate);
-        service.save(bill);
+        service.saveBill(bill);
 
         return delegate;
     }
@@ -154,7 +154,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
         payment.setVoidReason(reason);
         payment.setVoidedBy(Context.getAuthenticatedUser());
 
-        service.save(bill);
+        service.saveBill(bill);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
         Payment payment = findPayment(bill, uuid);
 
         bill.removePayment(payment);
-        service.save(bill);
+        service.saveBill(bill);
     }
 
     @Override


### PR DESCRIPTION
We’re currently getting an error when making a payment due to the validation in the `setLineItems(List<BillLineItem> lineItems)` method. This PR moves that validation into BillServiceImpl#validate instead.

Ticket: https://openmrs.atlassian.net/browse/O3-5246