### PR TITLE
O3-5198: Add CashPoint association to Payment entity

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
@@ -28,6 +28,8 @@ public class Payment extends BaseInstanceCustomizableData<PaymentMode, PaymentAt
 	
 	private Bill bill;
 	
+	private CashPoint cashPoint;
+	
 	private BigDecimal amount;
 	
 	private BigDecimal amountTendered;
@@ -79,5 +81,13 @@ public class Payment extends BaseInstanceCustomizableData<PaymentMode, PaymentAt
 	
 	public void setBill(Bill bill) {
 		this.bill = bill;
+	}
+	
+	public CashPoint getCashPoint() {
+		return cashPoint;
+	}
+	
+	public void setCashPoint(CashPoint cashPoint) {
+		this.cashPoint = cashPoint;
 	}
 }

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -199,6 +199,7 @@
 
 		<property name="amount" type="java.math.BigDecimal" column="amount" not-null="true"/>
 		<property name="amountTendered" type="java.math.BigDecimal" column="amount_tendered" not-null="true"/>
+		<many-to-one name="cashPoint" class="org.openmrs.module.billing.api.model.CashPoint" column="cash_point_id" not-null="false"/>
 
 		<set name="attributes" lazy="false" inverse="true" cascade="all-delete-orphan">
 			<key column="bill_payment_id"/>

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillTest.xml
@@ -43,7 +43,7 @@
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B9645D7B0007"/>
 	<cashier_bill_payment bill_payment_id="0" bill_id="0" payment_mode_id="0" amount="913.06" amount_tendered="1000.00"
-	                      creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                      cash_point_id="0" creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                      uuid="4028814B39B565A20139B9674C510008"/>
 	<cashier_bill_payment_attribute bill_payment_attribute_id="0" bill_payment_id="0" payment_mode_attribute_type_id="0"
 	                                value_reference="test 1 value" uuid="4028814B39B565A20139B96998DF0009"/>
@@ -59,7 +59,7 @@
 	                        creator="1" date_created="2012-02-01 00:00:00.0" voided="false"
 	                        uuid="5028814B39B565A20139B95FB3440005"/>
 	<cashier_bill_payment bill_payment_id="1" bill_id="1" payment_mode_id="0" amount="300.00" amount_tendered="300.00"
-	                      creator="1" date_created="2012-02-01 00:00:00.0" voided="false"
+	                      cash_point_id="0" creator="1" date_created="2012-02-01 00:00:00.0" voided="false"
 	                      uuid="5028814B39B565A20139B9674C510008"/>
 
 	<cashier_bill bill_id="2" receipt_number="test 3 receipt number" provider_id="0" patient_id="2"

--- a/fhir/src/test/resources/org/openmrs/module/billing/include/BillTest.xml
+++ b/fhir/src/test/resources/org/openmrs/module/billing/include/BillTest.xml
@@ -43,7 +43,7 @@
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B9645D7B0007"/>
 	<cashier_bill_payment bill_payment_id="0" bill_id="0" payment_mode_id="0" amount="913.06" amount_tendered="1000.00"
-	                      creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                      cash_point_id="0" creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                      uuid="4028814B39B565A20139B9674C510008"/>
 	<cashier_bill_payment_attribute bill_payment_attribute_id="0" bill_payment_id="0" payment_mode_attribute_type_id="0"
 	                                value_reference="test 1 value" uuid="4028814B39B565A20139B96998DF0009"/>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1095,4 +1095,36 @@
                                  baseTableName="bill_exemption_rule" baseColumnNames="voided_by"
                                  referencedTableName="users" referencedColumnNames="user_id"/>
     </changeSet>
+
+    <changeSet id="openmrs.billing-004-20251206-add-cashpoint-to-payment" author="RajPrakash681">
+        <comment>O3-5198: Add cash_point_id column to cashier_bill_payment table to track where each payment was taken</comment>
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="cashier_bill_payment" columnName="cash_point_id"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="cashier_bill_payment">
+            <column name="cash_point_id" type="int">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint constraintName="cashier_bill_payment_cash_point_id_fk"
+                                 baseTableName="cashier_bill_payment" baseColumnNames="cash_point_id"
+                                 referencedTableName="cashier_cash_point" referencedColumnNames="cash_point_id"/>
+        <createIndex tableName="cashier_bill_payment" indexName="cashier_bill_payment_cash_point_id_idx">
+            <column name="cash_point_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="openmrs.billing-005-20251206-migrate-existing-payment-cashpoints" author="RajPrakash681">
+        <comment>O3-5198: Migrate existing payments to use the cash_point_id from their associated bill</comment>
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="cashier_bill_payment" columnName="cash_point_id"/>
+        </preConditions>
+        <sql>
+            UPDATE cashier_bill_payment bp
+            SET cash_point_id = (SELECT b.cash_point_id FROM cashier_bill b WHERE b.bill_id = bp.bill_id)
+            WHERE bp.cash_point_id IS NULL
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Description
Adds a `cashPoint` field to the Payment entity to track which CashPoint the payment was taken at.

**Issue:** [O3-5198](https://openmrs.atlassian.net/browse/O3-5198)

## Implementation
- Added `cashPoint` field to Payment model with Hibernate mapping
- REST API auto-loads CashPoint from user's current timesheet (per Ian's guidance)
- Falls back to bill's CashPoint if no timesheet found
- Database migration adds column with FK and migrates existing payments



[O3-5198]: https://openmrs.atlassian.net/browse/O3-5198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ