### PR TITLE
Gate release on build, matching Bamboo stage order

### DIFF
--- a/.github/workflows/build-deploy-release.yml
+++ b/.github/workflows/build-deploy-release.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     name: Build and Test JDK 8
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -60,6 +59,7 @@ jobs:
 
   release:
     name: Release to Maven
+    needs: build
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
In Bamboo, Release was stage 3, only running after Build (stage 1) passed. Currently the release job runs independently, so a release could be triggered even if the code doesn't compile.

This adds `needs: build` to the release job. On `workflow_dispatch`, build runs first to verify tests pass, then release proceeds.

**Note:** This reverts the `if: github.event_name == 'push'` condition on the build job from PR #135, since build now needs to run on dispatch too as a prerequisite for release.