### PR TITLE
 (fix) O3-5422: Give BillLineItems their own BillLineItemStatus

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
+++ b/api/src/main/java/org/openmrs/module/billing/advice/GenerateBillFromOrderAdvice.java
@@ -19,6 +19,7 @@ import org.openmrs.module.billing.api.evaluator.ExemptionRuleEngine;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillExemption;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.BillableService;
 import org.openmrs.module.billing.api.model.BillableServiceStatus;
@@ -85,7 +86,8 @@ public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
 					if (!stockItems.isEmpty()) {
 						// check from the list for all exemptions
 						boolean isExempted = checkIfOrderIsExempted(workflowService, order, ExemptionType.COMMODITY);
-						BillStatus lineItemStatus = isExempted ? BillStatus.EXEMPTED : BillStatus.PENDING;
+						BillLineItemStatus lineItemStatus = isExempted ? BillLineItemStatus.EXEMPTED
+						        : BillLineItemStatus.PENDING;
 						addBillItemToBill(order, patient, cashierUUID, stockItems.get(0), null, (int) drugQuantity,
 						    order.getDateActivated(), lineItemStatus);
 					}
@@ -99,7 +101,8 @@ public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
 					List<BillableService> searchResult = service.getBillableServices(searchTemplate, null);
 					if (!searchResult.isEmpty()) {
 						boolean isExempted = checkIfOrderIsExempted(workflowService, order, ExemptionType.SERVICE);
-						BillStatus lineItemStatus = isExempted ? BillStatus.EXEMPTED : BillStatus.PENDING;
+						BillLineItemStatus lineItemStatus = isExempted ? BillLineItemStatus.EXEMPTED
+						        : BillLineItemStatus.PENDING;
 						addBillItemToBill(order, patient, cashierUUID, null, searchResult.get(0), 1,
 						    order.getDateActivated(), lineItemStatus);
 					}
@@ -168,7 +171,7 @@ public class GenerateBillFromOrderAdvice implements AfterReturningAdvice {
 	 * @param cashierUUID
 	 */
 	public void addBillItemToBill(Order order, Patient patient, String cashierUUID, StockItem stockitem,
-	        BillableService service, Integer quantity, Date orderDate, BillStatus lineItemStatus) {
+	        BillableService service, Integer quantity, Date orderDate, BillLineItemStatus lineItemStatus) {
 		try {
 			// Search for a bill
 			Bill activeBill = new Bill();

--- a/api/src/main/java/org/openmrs/module/billing/advice/OrderCreationMethodBeforeAdvice.java
+++ b/api/src/main/java/org/openmrs/module/billing/advice/OrderCreationMethodBeforeAdvice.java
@@ -37,6 +37,7 @@ import org.openmrs.module.billing.api.CashPointService;
 import org.openmrs.module.billing.api.ItemPriceService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.BillableService;
 import org.openmrs.module.billing.api.model.BillableServiceStatus;
@@ -141,7 +142,7 @@ public class OrderCreationMethodBeforeAdvice implements MethodBeforeAdvice {
 				billLineItem.setPrice(new BigDecimal("0.0"));
 			}
 			billLineItem.setQuantity(quantity);
-			billLineItem.setPaymentStatus(BillStatus.PENDING);
+			billLineItem.setPaymentStatus(BillLineItemStatus.PENDING);
 			billLineItem.setLineItemOrder(0);
 			
 			// Bill

--- a/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
@@ -177,7 +177,7 @@ public class Bill extends BaseOpenmrsData {
 				if (this.lineItems != null) {
 					for (BillLineItem lineItem : this.lineItems) {
 						if (lineItem != null && !lineItem.getVoided()) {
-							lineItem.setPaymentStatus(BillStatus.PAID);
+							lineItem.setPaymentStatus(BillLineItemStatus.PAID);
 						}
 					}
 				}

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
@@ -45,8 +45,7 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 	
 	private Integer lineItemOrder;
 	
-	private BillStatus paymentStatus; // this should only be set to either
-	// pending or paid
+	private BillLineItemStatus paymentStatus; 
 	
 	private Order order;
 	
@@ -133,11 +132,11 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 		this.lineItemOrder = lineItemOrder;
 	}
 	
-	public BillStatus getPaymentStatus() {
+	public BillLineItemStatus getPaymentStatus() {
 		return paymentStatus;
 	}
 	
-	public void setPaymentStatus(BillStatus paymentStatus) {
+	public void setPaymentStatus(BillLineItemStatus paymentStatus) {
 		this.paymentStatus = paymentStatus;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItemStatus.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItemStatus.java
@@ -1,0 +1,28 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+
+package org.openmrs.module.billing.api.model;
+
+/**
+ * The allowable statuses that a {@link BillLineItem} can have.
+ */
+public enum BillLineItemStatus {
+	
+	PENDING(),
+	PAID(),
+	CANCELLED(),
+	ADJUSTED(),
+	EXEMPTED();
+}

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -163,7 +163,7 @@
 		<property name="lineItemOrder" type="int" column="line_item_order"/>
 		<property name="paymentStatus" column="payment_status" not-null="true">
 			<type name="org.hibernate.type.EnumType">
-				<param name="enumClass">org.openmrs.module.billing.api.model.BillStatus</param>
+				<param name="enumClass">org.openmrs.module.billing.api.model.BillLineItemStatus</param>
 				<param name="type">12</param>
 			</type>
 		</property>

--- a/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
@@ -121,7 +121,7 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		
 		assertEquals(BillStatus.PAID, bill.getStatus());
-		assertEquals(BillStatus.PAID, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem.getPaymentStatus());
 	}
 	
 	@Test
@@ -177,7 +177,7 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		assertEquals(BillStatus.PAID, bill.getStatus());
 		// Only non-voided line items should be set to PAID
-		assertEquals(BillStatus.PAID, lineItem1.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem1.getPaymentStatus());
 	}
 	
 	@Test
@@ -212,8 +212,8 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		
 		assertEquals(BillStatus.PAID, bill.getStatus());
-		assertEquals(BillStatus.PAID, lineItem1.getPaymentStatus());
-		assertEquals(BillStatus.PAID, lineItem2.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem1.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem2.getPaymentStatus());
 		// Voided line items should not be updated
 		assertNull(voidedLineItem.getPaymentStatus());
 	}

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -33,6 +33,7 @@ import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.base.PagingInfo;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.Payment;
 import org.openmrs.module.billing.api.model.PaymentMode;
@@ -148,7 +149,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		StockItem stockItem = existingItem.getItem();
 		
 		BillLineItem lineItem = newBill.addLineItem(stockItem, BigDecimal.valueOf(150), "New price", 2);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setPaymentStatus(BillLineItemStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
 		Bill savedBill = billService.saveBill(newBill);
@@ -227,7 +228,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BillLineItem newLineItem = new BillLineItem();
 		newLineItem.setPrice(BigDecimal.valueOf(25.50));
 		newLineItem.setQuantity(2);
-		newLineItem.setPaymentStatus(BillStatus.PENDING);
+		newLineItem.setPaymentStatus(BillLineItemStatus.PENDING);
 		newLineItem.setLineItemOrder(pendingBill.getLineItems().size());
 		pendingBill.addLineItem(newLineItem);
 		
@@ -251,7 +252,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BillLineItem newLineItem = new BillLineItem();
 		newLineItem.setPrice(BigDecimal.valueOf(25.50));
 		newLineItem.setQuantity(2);
-		newLineItem.setPaymentStatus(BillStatus.PENDING);
+		newLineItem.setPaymentStatus(BillLineItemStatus.PENDING);
 		paidBill.addLineItem(newLineItem);
 		
 		// Should throw exception when saving (BillValidator catches line item
@@ -481,7 +482,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill templateBill = billService.getBill(0);
 		BillLineItem existingItem = templateBill.getLineItems().get(0);
 		BillLineItem lineItem = newBill.addLineItem(existingItem.getItem(), BigDecimal.valueOf(100), "Test price", 1);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setPaymentStatus(BillLineItemStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
 		Bill savedBill = billService.saveBill(newBill);

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1095,4 +1095,18 @@
                                  baseTableName="bill_exemption_rule" baseColumnNames="voided_by"
                                  referencedTableName="users" referencedColumnNames="user_id"/>
     </changeSet>
+	<changeSet id="openmrs.billing-004-20260320-migrate-line-item-payment-status" author="Edson Wasswa">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+				SELECT CASE WHEN EXISTS (
+					SELECT 1 FROM cashier_bill_line_item WHERE payment_status = 'POSTED'
+				) THEN 1 ELSE 0 END
+			</sqlCheck>
+		</preConditions>
+		<sql>
+			UPDATE cashier_bill_line_item
+			SET payment_status = 'PENDING'
+			WHERE payment_status = 'POSTED'
+		</sql>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION

Previously, line items were just reusing the main BillStatus enum. That with that a single line item can't be "POSTED" — only the parent bill can.

##To clean this up, I've split them apart:
 Added a new BillLineItemStatus enum that includes all the standard statuses (PENDING, PAID, CANCELLED, ADJUSTED, EXEMPTED) but leaves out POSTED as the ticket required.
Swapped out the old enum for the new one in the BillLineItem model and updated the Hibernate mappings ( Bill.hbm.xml ).
Updated the order creation advices and the status synchronization logic in Bill.java to use the new types.
 Updated the unit tests to make sure everything still passes.
 Database safety: I also added a quick Liquibase migration. Just in case there are any legacy line items in the database currently marked as POSTED , this safely flips them to PENDING so Hibernate doesn't crash when it tries to map them.

This is a fix to [https://openmrs.atlassian.net/issues?filter=-1&selectedIssue=O3-5422](https://openmrs.atlassian.net/issues?filter=-1&selectedIssue=O3-5422)

@NethmiRodrigo  please review this pr