### PR TITLE
Payments should be associated with a cashier

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Payment.java
@@ -13,14 +13,16 @@
  */
 package org.openmrs.module.billing.api.model;
 
+import java.math.BigDecimal;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.openmrs.module.billing.api.base.entity.model.BaseInstanceCustomizableData;
 
-import java.math.BigDecimal;
+import org.openmrs.Provider;
+import org.openmrs.module.billing.api.base.entity.model.BaseInstanceCustomizableData;
 
 /**
  * Model class that represents the {@link Bill} payment information.
@@ -45,6 +47,10 @@ public class Payment extends BaseInstanceCustomizableData<PaymentMode, PaymentAt
 	@Getter
 	@Setter
 	private BigDecimal amountTendered;
+	
+	@Getter
+	@Setter
+	private Provider cashier;
 	
 	public Integer getId() {
 		return paymentId;

--- a/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
+++ b/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
@@ -13,6 +13,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillLineItemService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.Payment;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -36,6 +37,7 @@ public class BillValidator implements Validator {
 			}
 			
 			validateLineItemsNotModified(bill, errors);
+			validateNewPaymentsHaveCashier(bill, errors);
 		}
 	}
 	
@@ -78,6 +80,22 @@ public class BillValidator implements Validator {
 			boolean hasNewLineItems = bill.getLineItems().stream().anyMatch(item -> item.getId() == null);
 			if (hasNewLineItems) {
 				errors.reject("billing.error.lineItemsCannotBeAddedToNonPendingBill");
+			}
+		}
+	}
+	
+	/**
+	 * Validates that any new (unsaved) non-voided payment has a cashier. Existing persisted payments
+	 * (id != null) are exempt to allow legacy data.
+	 */
+	private void validateNewPaymentsHaveCashier(Bill bill, Errors errors) {
+		if (bill.getPayments() == null) {
+			return;
+		}
+		for (Payment payment : bill.getPayments()) {
+			if (payment != null && !payment.getVoided() && payment.getId() == null && payment.getCashier() == null) {
+				errors.reject("billing.error.paymentCashierRequired");
+				return;
 			}
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
+++ b/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
@@ -36,8 +36,8 @@ public class BillValidator implements Validator {
 				errors.rejectValue("voided", "error.null");
 			}
 			
-			validateLineItemsNotModified(bill, errors);
 			validateNewPaymentsHaveCashier(bill, errors);
+			validateLineItemsNotModified(bill, errors);
 		}
 	}
 	

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -199,6 +199,7 @@
 
 		<property name="amount" type="java.math.BigDecimal" column="amount" not-null="true"/>
 		<property name="amountTendered" type="java.math.BigDecimal" column="amount_tendered" not-null="true"/>
+		<many-to-one name="cashier" class="org.openmrs.Provider" column="provider_id" not-null="false"/>
 
 		<set name="attributes" lazy="false" inverse="true" cascade="all-delete-orphan">
 			<key column="bill_payment_id"/>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -180,6 +180,7 @@ openhmis.cashier.payment.error.paymentMode.required=Payment mode is required.
 openhmis.cashier.payment.error.amountType=Amount needs to be a number
 openhmis.cashier.payment.error.amountRequired=Amount is required.
 openhmis.cashier.payment.confirm.paymentProcess=Are you sure you want to process a %s payment of %s?
+billing.error.paymentCashierRequired=Each payment must have an associated cashier.
 #setting page
 openhmis.cashier.setting.header=Cashier Settings
 openhmis.cashier.setting.adjustmentReason.field.header=Require Adjustment Reason

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
+import org.openmrs.Provider;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UnchangeableObjectException;
@@ -331,9 +332,12 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		
 		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
 		
+		Provider cashier = Context.getProviderService().getProvider(1);
+		
 		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
 		        .build();
 		payment.setInstanceType(paymentMode);
+		payment.setCashier(cashier);
 		
 		postedBill.addPayment(payment);
 		billService.saveBill(postedBill);

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -25,7 +25,6 @@ import org.openmrs.Provider;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UnchangeableObjectException;
-import org.openmrs.api.ValidationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
@@ -242,28 +241,6 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
-	public void saveBill_shouldThrowExceptionWhenAddingLineItemsToPaidBill() {
-		// Get the PAID bill from test data (bill_id=1)
-		Bill paidBill = billService.getBill(1);
-		assertNotNull(paidBill);
-		assertEquals(BillStatus.PAID, paidBill.getStatus());
-		
-		// Try to add a new line item
-		BillLineItem newLineItem = new BillLineItem();
-		newLineItem.setPrice(BigDecimal.valueOf(25.50));
-		newLineItem.setQuantity(2);
-		newLineItem.setPaymentStatus(BillStatus.PENDING);
-		paidBill.addLineItem(newLineItem);
-		
-		// Should throw exception when saving (BillValidator catches line item
-		// additions)
-		assertThrows(ValidationException.class, () -> billService.saveBill(paidBill));
-	}
-	
-	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
-	 */
-	@Test
 	public void saveBill_shouldAllowRemovingLineItemsFromPendingBill() {
 		// Get the PENDING bill from test data (bill_id=2)
 		Bill pendingBill = billService.getBill(2);
@@ -281,23 +258,6 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill savedBill = billService.saveBill(pendingBill);
 		assertNotNull(savedBill);
 		assertTrue(savedBill.getLineItems().size() < originalSize);
-	}
-	
-	/**
-	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
-	 */
-	@Test
-	public void saveBill_shouldThrowExceptionWhenRemovingLineItemsFromPaidBill() {
-		// Get the POSTED bill from test data (bill_id=1)
-		Bill postedBill = billService.getBill(1);
-		assertNotNull(postedBill);
-		assertEquals(BillStatus.PAID, postedBill.getStatus());
-		
-		BillLineItem itemToRemove = postedBill.getLineItems().get(0);
-		postedBill.removeLineItem(itemToRemove);
-		
-		// Should throw exception when saving (BillValidator catches line item removals)
-		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
 	}
 	
 	@Test
@@ -322,37 +282,6 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		billService.saveBill(postedBill);
 		
 		assertThrows(UnchangeableObjectException.class, Context::flushSession);
-	}
-	
-	@Test
-	public void saveBill_shouldThrowExceptionWhenNewPaymentHasNoCashier() {
-		Bill postedBill = billService.getBill(0);
-		assertNotNull(postedBill);
-		assertEquals(BillStatus.POSTED, postedBill.getStatus());
-		
-		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-		
-		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
-		        .build();
-		payment.setInstanceType(paymentMode);
-		// cashier intentionally NOT set
-		
-		postedBill.addPayment(payment);
-		
-		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
-	}
-	
-	@Test
-	public void saveBill_shouldTolerateExistingPaymentsWithNoCashier() {
-		// Legacy payments (with ID) that have no cashier must be tolerated
-		Bill paidBill = billService.getBill(1);
-		assertNotNull(paidBill);
-		assertFalse(paidBill.getPayments().isEmpty());
-		
-		Payment existingPayment = paidBill.getPayments().iterator().next();
-		assertNotNull(existingPayment.getId(), "Existing payment should have an ID");
-		
-		assertDoesNotThrow(() -> billService.saveBill(paidBill));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -325,6 +325,37 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
+	public void saveBill_shouldThrowExceptionWhenNewPaymentHasNoCashier() {
+		Bill postedBill = billService.getBill(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+		
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+		
+		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
+		        .build();
+		payment.setInstanceType(paymentMode);
+		// cashier intentionally NOT set
+		
+		postedBill.addPayment(payment);
+		
+		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
+	}
+	
+	@Test
+	public void saveBill_shouldTolerateExistingPaymentsWithNoCashier() {
+		// Legacy payments (with ID) that have no cashier must be tolerated
+		Bill paidBill = billService.getBill(1);
+		assertNotNull(paidBill);
+		assertFalse(paidBill.getPayments().isEmpty());
+		
+		Payment existingPayment = paidBill.getPayments().iterator().next();
+		assertNotNull(existingPayment.getId(), "Existing payment should have an ID");
+		
+		assertDoesNotThrow(() -> billService.saveBill(paidBill));
+	}
+	
+	@Test
 	public void saveBill_shouldAllowPaymentsForPostedBill() {
 		Bill postedBill = billService.getBill(0);
 		assertNotNull(postedBill);

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -328,35 +328,35 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill postedBill = billService.getBill(0);
 		assertNotNull(postedBill);
 		assertEquals(BillStatus.POSTED, postedBill.getStatus());
-
+		
 		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-
+		
 		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
 		        .build();
 		payment.setInstanceType(paymentMode);
 		payment.setCashier(providerService.getProvider(0));
-
+		
 		postedBill.addPayment(payment);
 		billService.saveBill(postedBill);
-
+		
 		assertDoesNotThrow(Context::flushSession);
 	}
-
+	
 	@Test
 	public void saveBill_shouldThrowValidationExceptionWhenPaymentHasNoCashier() {
 		Bill postedBill = billService.getBill(0);
 		assertNotNull(postedBill);
 		assertEquals(BillStatus.POSTED, postedBill.getStatus());
-
+		
 		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-
+		
 		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
 		        .build();
 		payment.setInstanceType(paymentMode);
 		// cashier intentionally NOT set — BillValidator must reject this
-
+		
 		postedBill.addPayment(payment);
-
+		
 		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
 	}
 	

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -21,10 +21,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
-import org.openmrs.Provider;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UnchangeableObjectException;
+import org.openmrs.api.ValidationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
@@ -241,6 +241,28 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
 	 */
 	@Test
+	public void saveBill_shouldThrowExceptionWhenAddingLineItemsToPaidBill() {
+		// Get the PAID bill from test data (bill_id=1)
+		Bill paidBill = billService.getBill(1);
+		assertNotNull(paidBill);
+		assertEquals(BillStatus.PAID, paidBill.getStatus());
+		
+		// Try to add a new line item
+		BillLineItem newLineItem = new BillLineItem();
+		newLineItem.setPrice(BigDecimal.valueOf(25.50));
+		newLineItem.setQuantity(2);
+		newLineItem.setPaymentStatus(BillStatus.PENDING);
+		paidBill.addLineItem(newLineItem);
+		
+		// Should throw exception when saving (BillValidator catches line item
+		// additions)
+		assertThrows(ValidationException.class, () -> billService.saveBill(paidBill));
+	}
+	
+	/**
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
+	 */
+	@Test
 	public void saveBill_shouldAllowRemovingLineItemsFromPendingBill() {
 		// Get the PENDING bill from test data (bill_id=2)
 		Bill pendingBill = billService.getBill(2);
@@ -258,6 +280,23 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill savedBill = billService.saveBill(pendingBill);
 		assertNotNull(savedBill);
 		assertTrue(savedBill.getLineItems().size() < originalSize);
+	}
+	
+	/**
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
+	 */
+	@Test
+	public void saveBill_shouldThrowExceptionWhenRemovingLineItemsFromPaidBill() {
+		// Get the POSTED bill from test data (bill_id=1)
+		Bill postedBill = billService.getBill(1);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.PAID, postedBill.getStatus());
+		
+		BillLineItem itemToRemove = postedBill.getLineItems().get(0);
+		postedBill.removeLineItem(itemToRemove);
+		
+		// Should throw exception when saving (BillValidator catches line item removals)
+		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
 	}
 	
 	@Test
@@ -289,20 +328,36 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill postedBill = billService.getBill(0);
 		assertNotNull(postedBill);
 		assertEquals(BillStatus.POSTED, postedBill.getStatus());
-		
+
 		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-		
-		Provider cashier = Context.getProviderService().getProvider(1);
-		
+
 		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
 		        .build();
 		payment.setInstanceType(paymentMode);
-		payment.setCashier(cashier);
-		
+		payment.setCashier(providerService.getProvider(0));
+
 		postedBill.addPayment(payment);
 		billService.saveBill(postedBill);
-		
+
 		assertDoesNotThrow(Context::flushSession);
+	}
+
+	@Test
+	public void saveBill_shouldThrowValidationExceptionWhenPaymentHasNoCashier() {
+		Bill postedBill = billService.getBill(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+
+		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
+		        .build();
+		payment.setInstanceType(paymentMode);
+		// cashier intentionally NOT set — BillValidator must reject this
+
+		postedBill.addPayment(payment);
+
+		assertThrows(ValidationException.class, () -> billService.saveBill(postedBill));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -25,7 +25,6 @@ import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.model.Bill;
-import org.openmrs.module.billing.api.model.BillLineItem;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.Payment;
 import org.openmrs.module.billing.api.model.PaymentMode;

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -16,13 +16,19 @@ package org.openmrs.module.billing.validator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillLineItem;
 import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.Payment;
+import org.openmrs.module.billing.api.model.PaymentMode;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -36,10 +42,13 @@ public class BillValidatorTest extends BaseModuleContextSensitiveTest {
 	
 	private BillService billService;
 	
+	private PaymentModeService paymentModeService;
+	
 	@BeforeEach
 	public void setup() {
 		billValidator = new BillValidator();
 		billService = Context.getService(BillService.class);
+		paymentModeService = Context.getService(PaymentModeService.class);
 		
 		executeDataSet(TestConstants.CORE_DATASET2);
 		executeDataSet(TestConstants.BASE_DATASET_DIR + "StockOperationType.xml");
@@ -71,6 +80,65 @@ public class BillValidatorTest extends BaseModuleContextSensitiveTest {
 		
 		// Unmodified PAID bills should pass validation - rejection happens only when
 		// attempting to modify line items
+		assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldRejectNewPaymentWithNoCashier() {
+		Bill postedBill = billService.getBill(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+		
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+		
+		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
+		        .build();
+		payment.setInstanceType(paymentMode);
+		// cashier intentionally NOT set
+		
+		postedBill.addPayment(payment);
+		
+		Errors errors = new BindException(postedBill, "bill");
+		billValidator.validate(postedBill, errors);
+		
+		assertTrue(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldTolerateExistingPaymentsWithNoCashier() {
+		// Legacy payments (with ID) that have no cashier must be tolerated
+		Bill paidBill = billService.getBill(1);
+		assertNotNull(paidBill);
+		assertFalse(paidBill.getPayments().isEmpty());
+		
+		Payment existingPayment = paidBill.getPayments().iterator().next();
+		assertNotNull(existingPayment.getId(), "Existing payment should have an ID");
+		
+		Errors errors = new BindException(paidBill, "bill");
+		billValidator.validate(paidBill, errors);
+		
+		assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldTolerateVoidedNewPaymentWithNoCashier() {
+		Bill postedBill = billService.getBill(0);
+		assertNotNull(postedBill);
+		assertEquals(BillStatus.POSTED, postedBill.getStatus());
+		
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+		
+		Payment payment = Payment.builder().amount(BigDecimal.valueOf(10.0)).amountTendered(BigDecimal.valueOf(10.0))
+		        .build();
+		payment.setInstanceType(paymentMode);
+		payment.setVoided(true);
+		// cashier intentionally NOT set
+		
+		postedBill.addPayment(payment);
+		
+		Errors errors = new BindException(postedBill, "bill");
+		billValidator.validate(postedBill, errors);
+		
 		assertFalse(errors.hasErrors());
 	}
 	

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -16,13 +16,20 @@ package org.openmrs.module.billing.validator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.Provider;
+import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.Payment;
+import org.openmrs.module.billing.api.model.PaymentMode;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -72,5 +79,72 @@ public class BillValidatorTest extends BaseModuleContextSensitiveTest {
 		// Unmodified PAID bills should pass validation - rejection happens only when
 		// attempting to modify line items
 		assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldRejectNewPaymentWithNoCashier() {
+		Bill bill = billService.getBill(0);
+		assertNotNull(bill);
+		
+		PaymentModeService paymentModeService = Context.getService(PaymentModeService.class);
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+		
+		Payment newPayment = new Payment();
+		newPayment.setAmount(BigDecimal.valueOf(100.0));
+		newPayment.setAmountTendered(BigDecimal.valueOf(100.0));
+		newPayment.setInstanceType(paymentMode);
+		// cashier intentionally NOT set — id is null (new payment)
+		
+		bill.addPayment(newPayment);
+		
+		Errors errors = new BindException(bill, "bill");
+		billValidator.validate(bill, errors);
+		
+		assertTrue(errors.hasErrors(), "Should reject bill with uncashiered new payment");
+		assertTrue(errors.getAllErrors().stream().anyMatch(e -> "billing.error.paymentCashierRequired".equals(e.getCode())),
+		    "Should use correct error code");
+	}
+	
+	@Test
+	public void validate_shouldNotRejectNewPaymentWithCashier() {
+		Bill bill = billService.getBill(0);
+		assertNotNull(bill);
+		
+		PaymentModeService paymentModeService = Context.getService(PaymentModeService.class);
+		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
+		
+		ProviderService providerService = Context.getProviderService();
+		Provider cashier = providerService.getProvider(1);
+		assertNotNull(cashier);
+		
+		Payment newPayment = new Payment();
+		newPayment.setAmount(BigDecimal.valueOf(100.0));
+		newPayment.setAmountTendered(BigDecimal.valueOf(100.0));
+		newPayment.setInstanceType(paymentMode);
+		newPayment.setCashier(cashier);
+		
+		bill.addPayment(newPayment);
+		
+		Errors errors = new BindException(bill, "bill");
+		billValidator.validate(bill, errors);
+		
+		assertFalse(errors.hasErrors(), "Should accept bill with cashiered new payment");
+	}
+	
+	@Test
+	public void validate_shouldNotRejectExistingPaymentWithNoCashier() {
+		// Legacy payments (with ID) that have no cashier must be tolerated
+		// BillTest.xml has bill_id=1 with bill_payment_id=1 and no provider_id
+		Bill bill = billService.getBill(1);
+		assertNotNull(bill);
+		assertFalse(bill.getPayments().isEmpty(), "Bill should have existing payments");
+		
+		Payment existingPayment = bill.getPayments().iterator().next();
+		assertNotNull(existingPayment.getId(), "Existing payment should have an ID");
+		
+		Errors errors = new BindException(bill, "bill");
+		billValidator.validate(bill, errors);
+		
+		assertFalse(errors.hasErrors(), "Should not reject bill with legacy payments missing cashier");
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -16,20 +16,13 @@ package org.openmrs.module.billing.validator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.math.BigDecimal;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openmrs.Provider;
-import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
-import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillStatus;
-import org.openmrs.module.billing.api.model.Payment;
-import org.openmrs.module.billing.api.model.PaymentMode;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -81,70 +74,4 @@ public class BillValidatorTest extends BaseModuleContextSensitiveTest {
 		assertFalse(errors.hasErrors());
 	}
 	
-	@Test
-	public void validate_shouldRejectNewPaymentWithNoCashier() {
-		Bill bill = billService.getBill(0);
-		assertNotNull(bill);
-		
-		PaymentModeService paymentModeService = Context.getService(PaymentModeService.class);
-		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-		
-		Payment newPayment = new Payment();
-		newPayment.setAmount(BigDecimal.valueOf(100.0));
-		newPayment.setAmountTendered(BigDecimal.valueOf(100.0));
-		newPayment.setInstanceType(paymentMode);
-		// cashier intentionally NOT set — id is null (new payment)
-		
-		bill.addPayment(newPayment);
-		
-		Errors errors = new BindException(bill, "bill");
-		billValidator.validate(bill, errors);
-		
-		assertTrue(errors.hasErrors(), "Should reject bill with uncashiered new payment");
-		assertTrue(errors.getAllErrors().stream().anyMatch(e -> "billing.error.paymentCashierRequired".equals(e.getCode())),
-		    "Should use correct error code");
-	}
-	
-	@Test
-	public void validate_shouldNotRejectNewPaymentWithCashier() {
-		Bill bill = billService.getBill(0);
-		assertNotNull(bill);
-		
-		PaymentModeService paymentModeService = Context.getService(PaymentModeService.class);
-		PaymentMode paymentMode = paymentModeService.getPaymentMode(0);
-		
-		ProviderService providerService = Context.getProviderService();
-		Provider cashier = providerService.getProvider(1);
-		assertNotNull(cashier);
-		
-		Payment newPayment = new Payment();
-		newPayment.setAmount(BigDecimal.valueOf(100.0));
-		newPayment.setAmountTendered(BigDecimal.valueOf(100.0));
-		newPayment.setInstanceType(paymentMode);
-		newPayment.setCashier(cashier);
-		
-		bill.addPayment(newPayment);
-		
-		Errors errors = new BindException(bill, "bill");
-		billValidator.validate(bill, errors);
-		
-		assertFalse(errors.hasErrors(), "Should accept bill with cashiered new payment");
-	}
-	
-	@Test
-	public void validate_shouldNotRejectExistingPaymentWithNoCashier() {
-		// Legacy payments (with ID) that have no cashier must be tolerated
-		// BillTest.xml has bill_id=1 with bill_payment_id=1 and no provider_id
-		Bill bill = billService.getBill(1);
-		assertNotNull(bill);
-		assertFalse(bill.getPayments().isEmpty(), "Bill should have existing payments");
-		
-		Payment existingPayment = bill.getPayments().iterator().next();
-		assertNotNull(existingPayment.getId(), "Existing payment should have an ID");
-		
-		Errors errors = new BindException(bill, "bill");
-		billValidator.validate(bill, errors);
-		
-		assertFalse(errors.hasErrors(), "Should not reject bill with legacy payments missing cashier");
-	}
 }

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -106,6 +106,14 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		}
 		BaseRestDataResource.syncCollection(instance.getPayments(), payments);
 		for (Payment payment : instance.getPayments()) {
+			if (payment.getId() == null && payment.getCashier() == null) {
+				Provider cashier = getCurrentCashier();
+				if (cashier == null) {
+					throw new RestClientException("Couldn't find Provider for the current user ("
+					        + Context.getAuthenticatedUser().getUsername() + ")");
+				}
+				payment.setCashier(cashier);
+			}
 			instance.addPayment(payment);
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -103,12 +103,15 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			instance.setPayments(new HashSet<Payment>(payments.size()));
 		}
 		BaseRestDataResource.syncCollection(instance.getPayments(), payments);
+		Provider cashier = null;
 		for (Payment payment : instance.getPayments()) {
 			if (payment.getId() == null && payment.getCashier() == null) {
-				Provider cashier = getCurrentCashier();
 				if (cashier == null) {
-					throw new RestClientException("The current user ("
-					        + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
+					cashier = getCurrentCashier();
+					if (cashier == null) {
+						throw new RestClientException("The current user ("
+						        + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
+					}
 				}
 				payment.setCashier(cashier);
 			}

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -15,7 +15,6 @@ package org.openmrs.module.billing.web.rest.resource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,10 +22,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Provider;
-import org.openmrs.User;
 import org.openmrs.api.AdministrationService;
-import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.base.ProviderUtil;
 import org.openmrs.module.billing.ModuleSettings;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.ITimesheetService;
@@ -215,13 +213,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 	}
 	
 	private Provider getCurrentCashier() {
-		User currentUser = Context.getAuthenticatedUser();
-		ProviderService service = Context.getProviderService();
-		Collection<Provider> providers = service.getProvidersByPerson(currentUser.getPerson());
-		if (!providers.isEmpty()) {
-			return providers.iterator().next();
-		}
-		return null;
+		return ProviderUtil.getCurrentProvider();
 	}
 	
 	private void loadBillCashPoint(Bill bill) {

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -107,8 +107,8 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			if (payment.getId() == null && payment.getCashier() == null) {
 				Provider cashier = getCurrentCashier();
 				if (cashier == null) {
-					throw new RestClientException("Couldn't find Provider for the current user ("
-					        + Context.getAuthenticatedUser().getUsername() + ")");
+					throw new RestClientException("The current user ("
+					        + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
 				}
 				payment.setCashier(cashier);
 			}
@@ -149,10 +149,10 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			if (bill.getCashier() == null) {
 				Provider cashier = getCurrentCashier();
 				if (cashier == null) {
-					throw new RestClientException("Couldn't find Provider for the current user ("
-					        + Context.getAuthenticatedUser().getUsername() + ")");
+					throw new RestClientException("The current user ("
+					        + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
 				}
-				
+
 				bill.setCashier(cashier);
 			}
 			

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
@@ -74,8 +74,18 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 		description.addProperty("attributes");
 		description.addProperty("amount");
 		description.addProperty("amountTendered");
+		description.addProperty("cashier");
 		
 		return description;
+	}
+	
+	@PropertySetter("cashier")
+	public void setCashier(Payment instance, String uuid) {
+		Provider provider = Context.getProviderService().getProviderByUuid(uuid);
+		if (provider == null) {
+			throw new ObjectNotFoundException();
+		}
+		instance.setCashier(provider);
 	}
 	
 	// Work around TypeVariable issue on base generic property (BaseCustomizableInstanceData.getInstanceType)
@@ -136,11 +146,14 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 	
 	@Override
 	public Payment save(Payment delegate) {
-		Provider cashier = ProviderUtil.getCurrentProvider();
-		if (cashier == null) {
-			throw new APIException("The authenticated user is not associated with a Provider and cannot process payments.");
+		if (delegate.getCashier() == null) {
+			Provider cashier = ProviderUtil.getCurrentProvider();
+			if (cashier == null) {
+				throw new APIException(
+				        "The authenticated user is not associated with a Provider and cannot process payments.");
+			}
+			delegate.setCashier(cashier);
 		}
-		delegate.setCashier(cashier);
 		
 		BillService service = Context.getService(BillService.class);
 		Bill bill = delegate.getBill();

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.billing.web.rest.resource;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Provider;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
@@ -81,6 +82,9 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 	
 	@PropertySetter("cashier")
 	public void setCashier(Payment instance, String uuid) {
+		if (StringUtils.isBlank(uuid)) {
+			throw new APIException("Cashier UUID must not be null or blank.");
+		}
 		Provider provider = Context.getProviderService().getProviderByUuid(uuid);
 		if (provider == null) {
 			throw new ObjectNotFoundException();

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/PaymentResource.java
@@ -13,8 +13,11 @@
  */
 package org.openmrs.module.billing.web.rest.resource;
 
+import org.openmrs.Provider;
+import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.base.ProviderUtil;
 import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.web.base.resource.BaseRestDataResource;
 import org.openmrs.module.billing.api.model.Bill;
@@ -55,6 +58,7 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 			description.addProperty("attributes");
 			description.addProperty("amount");
 			description.addProperty("amountTendered");
+			description.addProperty("cashier", Representation.REF);
 			description.addProperty("dateCreated");
 			description.addProperty("voided");
 			return description;
@@ -132,6 +136,12 @@ public class PaymentResource extends DelegatingSubResource<Payment, Bill, BillRe
 	
 	@Override
 	public Payment save(Payment delegate) {
+		Provider cashier = ProviderUtil.getCurrentProvider();
+		if (cashier == null) {
+			throw new APIException("The authenticated user is not associated with a Provider and cannot process payments.");
+		}
+		delegate.setCashier(cashier);
+		
 		BillService service = Context.getService(BillService.class);
 		Bill bill = delegate.getBill();
 		bill.addPayment(delegate);

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1106,6 +1106,7 @@
         <addForeignKeyConstraint
             constraintName="cashier_bill_payment_provider_id_fk"
             baseTableName="cashier_bill_payment" baseColumnNames="provider_id"
-            referencedTableName="provider" referencedColumnNames="provider_id"/>
+            referencedTableName="provider" referencedColumnNames="provider_id"
+            onDelete="SET NULL" onUpdate="CASCADE"/>
     </changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1099,8 +1099,9 @@
     <changeSet id="openmrs.billing-004-20260320-add-provider-id-to-bill-payment" author="Nethmi Rodrigo">
 		<comment>Add cashier (provider) for each payment to track which cashier processed the payment</comment>
         <addColumn tableName="cashier_bill_payment">
-            <column name="provider_id" type="int"/>
-			<constraints nullable="true"/>
+            <column name="provider_id" type="int">
+      		<constraints nullable="true"/>
+  			</column>
         </addColumn>
         <addForeignKeyConstraint
             constraintName="cashier_bill_payment_provider_id_fk"

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1097,11 +1097,11 @@
     </changeSet>
 
     <changeSet id="openmrs.billing-004-20260320-add-provider-id-to-bill-payment" author="Nethmi Rodrigo">
-		<comment>Add cashier (provider) for each payment to track which cashier processed the payment</comment>
+        <comment>Add cashier (provider) for each payment to track which cashier processed the payment</comment>
         <addColumn tableName="cashier_bill_payment">
             <column name="provider_id" type="int">
-      		<constraints nullable="true"/>
-  			</column>
+                <constraints nullable="true"/>
+            </column>
         </addColumn>
         <addForeignKeyConstraint
             constraintName="cashier_bill_payment_provider_id_fk"

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1095,4 +1095,17 @@
                                  baseTableName="bill_exemption_rule" baseColumnNames="voided_by"
                                  referencedTableName="users" referencedColumnNames="user_id"/>
     </changeSet>
+
+    <changeSet id="openmrs.billing-004-20260320-add-provider-id-to-bill-payment" author="billing">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="cashier_bill_payment" columnName="provider_id"/></not>
+        </preConditions>
+        <addColumn tableName="cashier_bill_payment">
+            <column name="provider_id" type="int"/>
+        </addColumn>
+        <addForeignKeyConstraint
+            constraintName="cashier_bill_payment_provider_id_fk"
+            baseTableName="cashier_bill_payment" baseColumnNames="provider_id"
+            referencedTableName="provider" referencedColumnNames="provider_id"/>
+    </changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1096,12 +1096,11 @@
                                  referencedTableName="users" referencedColumnNames="user_id"/>
     </changeSet>
 
-    <changeSet id="openmrs.billing-004-20260320-add-provider-id-to-bill-payment" author="billing">
-        <preConditions onFail="MARK_RAN">
-            <not><columnExists tableName="cashier_bill_payment" columnName="provider_id"/></not>
-        </preConditions>
+    <changeSet id="openmrs.billing-004-20260320-add-provider-id-to-bill-payment" author="Nethmi Rodrigo">
+		<comment>Add cashier (provider) for each payment to track which cashier processed the payment</comment>
         <addColumn tableName="cashier_bill_payment">
             <column name="provider_id" type="int"/>
+			<constraints nullable="true"/>
         </addColumn>
         <addForeignKeyConstraint
             constraintName="cashier_bill_payment_provider_id_fk"

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
@@ -1,0 +1,126 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.billing.web.rest.resource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.openmrs.Provider;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.base.ProviderUtil;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.Payment;
+
+/**
+ * Unit tests for {@link PaymentResource}
+ */
+public class PaymentResourceTest {
+	
+	private PaymentResource resource;
+	
+	private BillService billService;
+	
+	private MockedStatic<Context> contextMock;
+	
+	private MockedStatic<ProviderUtil> providerUtilMock;
+	
+	@Before
+	public void setUp() {
+		resource = new PaymentResource();
+		billService = mock(BillService.class);
+		
+		contextMock = mockStatic(Context.class);
+		contextMock.when(() -> Context.getService(BillService.class)).thenReturn(billService);
+		
+		providerUtilMock = mockStatic(ProviderUtil.class);
+	}
+	
+	@After
+	public void tearDown() {
+		if (contextMock != null) {
+			contextMock.close();
+		}
+		if (providerUtilMock != null) {
+			providerUtilMock.close();
+		}
+	}
+	
+	@Test
+	public void save_shouldSetCashierFromAuthenticatedProvider() {
+		Provider cashier = new Provider();
+		cashier.setId(1);
+		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(cashier);
+		
+		Bill bill = new Bill();
+		bill.setId(1);
+		Payment payment = new Payment();
+		payment.setBill(bill);
+		payment.setAmount(BigDecimal.TEN);
+		payment.setAmountTendered(BigDecimal.TEN);
+		
+		when(billService.saveBill(bill)).thenReturn(bill);
+		
+		resource.save(payment);
+		
+		assertNotNull("Cashier should be set on the payment", payment.getCashier());
+		assertSame("Cashier should be the current provider", cashier, payment.getCashier());
+		verify(billService).saveBill(bill);
+	}
+	
+	@Test(expected = APIException.class)
+	public void save_shouldThrowAPIExceptionWhenNoProviderLinkedToUser() {
+		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(null);
+		
+		Bill bill = new Bill();
+		bill.setId(1);
+		Payment payment = new Payment();
+		payment.setBill(bill);
+		
+		resource.save(payment);
+	}
+	
+	@Test
+	public void save_shouldSetCashierBeforeAddingPaymentToBill() {
+		Provider cashier = new Provider();
+		cashier.setId(1);
+		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(cashier);
+		
+		Bill bill = new Bill();
+		bill.setId(1);
+		Payment payment = new Payment();
+		payment.setBill(bill);
+		payment.setAmount(BigDecimal.TEN);
+		payment.setAmountTendered(BigDecimal.TEN);
+		
+		when(billService.saveBill(bill)).thenReturn(bill);
+		
+		resource.save(payment);
+		
+		assertNotNull(payment.getCashier());
+		assertTrue(bill.getPayments().contains(payment));
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
@@ -13,9 +13,10 @@
  */
 package org.openmrs.module.billing.web.rest.resource;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -23,9 +24,9 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.openmrs.Provider;
 import org.openmrs.api.APIException;
@@ -48,7 +49,7 @@ public class PaymentResourceTest {
 	
 	private MockedStatic<ProviderUtil> providerUtilMock;
 	
-	@Before
+	@BeforeEach
 	public void setUp() {
 		resource = new PaymentResource();
 		billService = mock(BillService.class);
@@ -59,7 +60,7 @@ public class PaymentResourceTest {
 		providerUtilMock = mockStatic(ProviderUtil.class);
 	}
 	
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (contextMock != null) {
 			contextMock.close();
@@ -86,12 +87,12 @@ public class PaymentResourceTest {
 		
 		resource.save(payment);
 		
-		assertNotNull("Cashier should be set on the payment", payment.getCashier());
-		assertSame("Cashier should be the current provider", cashier, payment.getCashier());
+		assertNotNull(payment.getCashier(), "Cashier should be set on the payment");
+		assertSame(cashier, payment.getCashier(), "Cashier should be the current provider");
 		verify(billService).saveBill(bill);
 	}
 	
-	@Test(expected = APIException.class)
+	@Test
 	public void save_shouldThrowAPIExceptionWhenNoProviderLinkedToUser() {
 		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(null);
 		
@@ -100,7 +101,7 @@ public class PaymentResourceTest {
 		Payment payment = new Payment();
 		payment.setBill(bill);
 		
-		resource.save(payment);
+		assertThrows(APIException.class, () -> resource.save(payment));
 	}
 	
 	@Test
@@ -124,7 +125,7 @@ public class PaymentResourceTest {
 		
 		resource.save(payment);
 		
-		assertSame("Client-provided cashier should not be overwritten", clientCashier, payment.getCashier());
+		assertSame(clientCashier, payment.getCashier(), "Client-provided cashier should not be overwritten");
 	}
 	
 	@Test
@@ -144,7 +145,7 @@ public class PaymentResourceTest {
 		
 		resource.save(payment);
 		
-		assertSame("Authenticated user's provider should be used as fallback", cashier, payment.getCashier());
+		assertSame(cashier, payment.getCashier(), "Authenticated user's provider should be used as fallback");
 	}
 	
 	@Test

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/PaymentResourceTest.java
@@ -104,6 +104,50 @@ public class PaymentResourceTest {
 	}
 	
 	@Test
+	public void save_shouldUseClientProvidedCashierWhenSet() {
+		Provider clientCashier = new Provider();
+		clientCashier.setId(2);
+		
+		Provider authenticatedCashier = new Provider();
+		authenticatedCashier.setId(99);
+		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(authenticatedCashier);
+		
+		Bill bill = new Bill();
+		bill.setId(1);
+		Payment payment = new Payment();
+		payment.setBill(bill);
+		payment.setAmount(BigDecimal.TEN);
+		payment.setAmountTendered(BigDecimal.TEN);
+		payment.setCashier(clientCashier);
+		
+		when(billService.saveBill(bill)).thenReturn(bill);
+		
+		resource.save(payment);
+		
+		assertSame("Client-provided cashier should not be overwritten", clientCashier, payment.getCashier());
+	}
+	
+	@Test
+	public void save_shouldFallbackToAuthenticatedUserWhenNoCashierProvided() {
+		Provider cashier = new Provider();
+		cashier.setId(1);
+		providerUtilMock.when(ProviderUtil::getCurrentProvider).thenReturn(cashier);
+		
+		Bill bill = new Bill();
+		bill.setId(1);
+		Payment payment = new Payment();
+		payment.setBill(bill);
+		payment.setAmount(BigDecimal.TEN);
+		payment.setAmountTendered(BigDecimal.TEN);
+		
+		when(billService.saveBill(bill)).thenReturn(bill);
+		
+		resource.save(payment);
+		
+		assertSame("Authenticated user's provider should be used as fallback", cashier, payment.getCashier());
+	}
+	
+	@Test
 	public void save_shouldSetCashierBeforeAddingPaymentToBill() {
 		Provider cashier = new Provider();
 		cashier.setId(1);


### PR DESCRIPTION
This PR adds back the functionality that was introduced in this [PR](https://github.com/openmrs/openmrs-module-billing/pull/109), that we had to revert because it was merged in during the release code freeze. This basically does the same except for getting the cashier from the authenticated user, while previously it needed to be sent from the client.
- Adds a cashier field to the Payment model (nullable for backwards compatibility with legacy payments)                                               
- Auto-sets the cashier from the authenticated user at the REST layer — both in PaymentResource
  (sub-resource endpoint) and BillResource (embedded payments on bill create/update)                        
- Validates that any new payment being saved has a cashier assigned; existing payments without a cashier
  (legacy data) are allowed                                                                               
- Exposes cashier in the payment REST representation 