### PR TITLE
O3-5199: make Bill.cashier optional

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGenerator.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGenerator.java
@@ -117,14 +117,14 @@ public class SequentialReceiptNumberGenerator implements IReceiptNumberGenerator
 		
 		switch (model.getGroupingType()) {
 			case CASHIER:
-				result = model.getCashierPrefix() + bill.getCashier().getId();
+				result = model.getCashierPrefix() + (bill.getCashier() != null ? bill.getCashier().getId() : "");
 				break;
 			case CASH_POINT:
 				result = model.getCashPointPrefix() + bill.getCashPoint().getId();
 				break;
 			case CASHIER_AND_CASH_POINT:
-				result = model.getCashierPrefix() + bill.getCashier().getId() + model.getSeparator()
-				        + model.getCashPointPrefix() + bill.getCashPoint().getId();
+				result = model.getCashierPrefix() + (bill.getCashier() != null ? bill.getCashier().getId() : "")
+				        + model.getSeparator() + model.getCashPointPrefix() + bill.getCashPoint().getId();
 				break;
 			default:
 				break;

--- a/api/src/main/java/org/openmrs/module/billing/util/ReceiptGenerator.java
+++ b/api/src/main/java/org/openmrs/module/billing/util/ReceiptGenerator.java
@@ -272,8 +272,10 @@ public class ReceiptGenerator {
 			doc.add(divider);
 			doc.add(amountDueSection);
 			doc.add(divider);
-			doc.add(new Paragraph("You were served by " + bill.getCashier().getName()).setFont(footerSectionFont)
-			        .setFontSize(8).setTextAlignment(TextAlignment.CENTER));
+			if (bill.getCashier() != null) {
+				doc.add(new Paragraph("You were served by " + bill.getCashier().getName()).setFont(footerSectionFont)
+				        .setFontSize(8).setTextAlignment(TextAlignment.CENTER));
+			}
 		}
 		catch (Exception e) {
 			LOG.error("Exception caught while writing PDF to stream", e);

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -103,7 +103,7 @@
 		<discriminator column="bill_id" insert="false"/>
 
 		<property name="receiptNumber" type="java.lang.String" column="receipt_number" not-null="false" length="255"/>
-		<many-to-one name="cashier" class="org.openmrs.Provider" not-null="true" column="provider_id"/>
+		<many-to-one name="cashier" class="org.openmrs.Provider" not-null="false" column="provider_id"/>
 		<many-to-one name="patient" class="org.openmrs.Patient" not-null="true" column="patient_id"/>
 		<many-to-one name="cashPoint" class="org.openmrs.module.billing.api.model.CashPoint" not-null="true"
 		             column="cash_point_id"/>

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorTest.java
@@ -316,6 +316,56 @@ public class SequentialReceiptNumberGeneratorTest {
 		generator.generateNumber(null);
 	}
 	
+	/**
+	 * @verifies Handle null cashier when grouping type is CASHIER
+	 * @see SequentialReceiptNumberGenerator#generateNumber(Bill)
+	 */
+	@Test
+	public void generateNumber_shouldHandleNullCashierWithCashierGroupingType() {
+		SequentialReceiptNumberGeneratorModel model = new SequentialReceiptNumberGeneratorModel();
+		model.setGroupingType(SequentialReceiptNumberGenerator.GroupingType.CASHIER);
+		model.setSeparator("");
+		model.setSequencePadding(4);
+		model.setCashierPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASHIER_PREFIX);
+		model.setCashPointPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASH_POINT_PREFIX);
+		model.setSequenceType(SequentialReceiptNumberGenerator.SequenceType.COUNTER);
+		model.setIncludeCheckDigit(false);
+
+		when(service.getOnly()).thenReturn(model);
+		when(service.reserveNextSequence("P")).thenReturn(5);
+		generator.load();
+
+		Bill bill = createBillWithoutCashier(3);
+		String number = generator.generateNumber(bill);
+		Assert.assertNotNull(number);
+		Assert.assertEquals("P0005", number);
+	}
+
+	/**
+	 * @verifies Handle null cashier when grouping type is CASHIER_AND_CASH_POINT
+	 * @see SequentialReceiptNumberGenerator#generateNumber(Bill)
+	 */
+	@Test
+	public void generateNumber_shouldHandleNullCashierWithCashierAndCashPointGroupingType() {
+		SequentialReceiptNumberGeneratorModel model = new SequentialReceiptNumberGeneratorModel();
+		model.setGroupingType(SequentialReceiptNumberGenerator.GroupingType.CASHIER_AND_CASH_POINT);
+		model.setSeparator("");
+		model.setSequencePadding(4);
+		model.setCashierPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASHIER_PREFIX);
+		model.setCashPointPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASH_POINT_PREFIX);
+		model.setSequenceType(SequentialReceiptNumberGenerator.SequenceType.COUNTER);
+		model.setIncludeCheckDigit(false);
+
+		when(service.getOnly()).thenReturn(model);
+		when(service.reserveNextSequence("PCP3")).thenReturn(7);
+		generator.load();
+
+		Bill bill = createBillWithoutCashier(3);
+		String number = generator.generateNumber(bill);
+		Assert.assertNotNull(number);
+		Assert.assertEquals("PCP30007", number);
+	}
+
 	protected Bill createBill(int cashierId, int cashPointId) {
 		Provider provider = new Provider(cashierId);
 		CashPoint cashPoint = new CashPoint();
@@ -323,7 +373,15 @@ public class SequentialReceiptNumberGeneratorTest {
 		Bill bill = new Bill();
 		bill.setCashier(provider);
 		bill.setCashPoint(cashPoint);
-		
+
+		return bill;
+	}
+
+	protected Bill createBillWithoutCashier(int cashPointId) {
+		CashPoint cashPoint = new CashPoint();
+		cashPoint.setId(cashPointId);
+		Bill bill = new Bill();
+		bill.setCashPoint(cashPoint);
 		return bill;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/util/ReceiptGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/util/ReceiptGeneratorTest.java
@@ -95,6 +95,17 @@ public class ReceiptGeneratorTest extends BaseModuleContextSensitiveTest {
 		assertTrue(pdfText.contains("KES"), "PDF should contain configured currency symbol KES but was: " + pdfText);
 	}
 	
+	@Test
+	public void createBillReceipt_shouldNotThrowExceptionWhenCashierIsNull() throws Exception {
+		Bill bill = createTestBill();
+		bill.setCashier(null);
+
+		byte[] pdfBytes = ReceiptGenerator.createBillReceipt(bill);
+
+		assertNotNull(pdfBytes);
+		assertTrue(pdfBytes.length > 0);
+	}
+
 	private Bill createTestBill() {
 		Patient patient = patientService.getPatient(0);
 		

--- a/api/src/test/java/org/openmrs/module/billing/util/ReceiptGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/util/ReceiptGeneratorTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.billing.util;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -104,6 +105,9 @@ public class ReceiptGeneratorTest extends BaseModuleContextSensitiveTest {
 
 		assertNotNull(pdfBytes);
 		assertTrue(pdfBytes.length > 0);
+		String pdfText = extractTextFromPdf(pdfBytes);
+		assertFalse(pdfText.contains("You were served by"),
+		    "PDF should not contain cashier line when cashier is null");
 	}
 
 	private Bill createTestBill() {

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -145,16 +145,6 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		//TODO: Test all the ways that this could fail
 		
 		if (bill.getId() == null) {
-			if (bill.getCashier() == null) {
-				Provider cashier = getCurrentCashier();
-				if (cashier == null) {
-					throw new RestClientException(
-					        "The current user (" + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
-				}
-				
-				bill.setCashier(cashier);
-			}
-			
 			if (bill.getCashPoint() == null) {
 				loadBillCashPoint(bill);
 			}
@@ -216,9 +206,18 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 	}
 	
 	private void loadBillCashPoint(Bill bill) {
-		ITimesheetService service = Context.getService(ITimesheetService.class);
-		Timesheet timesheet = service.getCurrentTimesheet(bill.getCashier());
-		if (timesheet == null) {
+		if (bill.getCashier() != null) {
+			ITimesheetService service = Context.getService(ITimesheetService.class);
+			Timesheet timesheet = service.getCurrentTimesheet(bill.getCashier());
+			if (timesheet != null) {
+				CashPoint cashPoint = timesheet.getCashPoint();
+				if (cashPoint == null) {
+					throw new RestClientException("No cash points defined for the current timesheet!");
+				}
+				bill.setCashPoint(cashPoint);
+				return;
+			}
+			// timesheet is null — check if a timesheet is required
 			AdministrationService adminService = Context.getAdministrationService();
 			boolean timesheetRequired;
 			try {
@@ -228,21 +227,16 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			catch (Exception e) {
 				timesheetRequired = false;
 			}
-			
 			if (timesheetRequired) {
 				throw new RestClientException("A current timesheet does not exist for cashier " + bill.getCashier());
-			} else if (bill.getBillAdjusted() != null) {
-				// If this is an adjusting bill, copy cash point from billAdjusted
-				bill.setCashPoint(bill.getBillAdjusted().getCashPoint());
-			} else {
-				throw new RestClientException("Cash point cannot be null!");
 			}
+		}
+		// No cashier, or no timesheet and not required — copy from adjusted bill or fail
+		if (bill.getBillAdjusted() != null) {
+			// If this is an adjusting bill, copy cash point from billAdjusted
+			bill.setCashPoint(bill.getBillAdjusted().getCashPoint());
 		} else {
-			CashPoint cashPoint = timesheet.getCashPoint();
-			if (cashPoint == null) {
-				throw new RestClientException("No cash points defined for the current timesheet!");
-			}
-			bill.setCashPoint(cashPoint);
+			throw new RestClientException("Cash point cannot be null!");
 		}
 	}
 	

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1120,4 +1120,12 @@
             referencedTableName="provider" referencedColumnNames="provider_id"
             onDelete="SET NULL" onUpdate="CASCADE"/>
     </changeSet>
+
+    <changeSet id="openmrs.billing-005-make-bill-cashier-optional" author="rjnt4">
+        <comment>Make cashier (provider_id) optional on cashier_bill — cashier belongs to payments, not bills</comment>
+        <dropNotNullConstraint
+            tableName="cashier_bill"
+            columnName="provider_id"
+            columnDataType="int"/>
+    </changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1121,7 +1121,7 @@
             onDelete="SET NULL" onUpdate="CASCADE"/>
     </changeSet>
 
-    <changeSet id="openmrs.billing-005-make-bill-cashier-optional" author="rjnt4">
+    <changeSet id="openmrs.billing-005-20260410-make-bill-cashier-optional" author="Raj prakash">
         <comment>Make cashier (provider_id) optional on cashier_bill — cashier belongs to payments, not bills</comment>
         <dropNotNullConstraint
             tableName="cashier_bill"


### PR DESCRIPTION
## Summary
- Bill.cashier is now optional — bills do not belong to cashiers, payments do
- Removed forced auto-assignment of cashier on bill creation in BillResource
- Updated loadBillCashPoint to handle null cashier gracefully
- Added Liquibase migration to drop NOT NULL constraint on cashier_bill.provider_id


