### PR TITLE
Separate OWASP dependency check into its own job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,18 +7,23 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   build:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
     with:
       java_versions: '["8", "11", "17", "21"]'
       main_java_version: '8'
+      run_owasp_check: false
+    secrets:
+      MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+      MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}
+
+  owasp-dependency-check:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/owasp-dependency-check.yml@main
+    with:
+      java_version: '8'
     secrets:
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-      MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-      MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}  
       BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Separate OWASP dependency check into a standalone workflow job
- OWASP check only runs on push and workflow_dispatch (not on PRs)
- Build job no longer runs the OWASP check inline or needs the NVD_API_KEY secret

## Test plan
- [ ] Verify build job still passes
- [ ] Verify OWASP dependency check runs on push to the default branch
- [ ] Verify OWASP dependency check does not run on pull requests
