### PR TITLE
Migrate build to maven-parent-openmrs-module 2.1.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>
-			<type>test-jar</type>
+			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 
@@ -124,10 +124,6 @@
 		</testResources>
 
 		<plugins>
-			<plugin>
-				<groupId>net.revelc.code.formatter</groupId>
-				<artifactId>formatter-maven-plugin</artifactId>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -25,7 +25,8 @@
         <dependency>
             <groupId>org.openmrs.api</groupId>
             <artifactId>openmrs-api</artifactId>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openmrs.web</groupId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>
-			<type>test-jar</type>
+			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 
@@ -155,52 +155,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>net.revelc.code.formatter</groupId>
-					<artifactId>formatter-maven-plugin</artifactId>
-				</plugin>
-				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
 					<configuration>
 						<includeEmptyDirs>true</includeEmptyDirs>
-					</configuration>
-				</plugin>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.openmrs.maven.plugins</groupId>
-										<artifactId>maven-openmrs-plugin</artifactId>
-										<versionRange>[1.0.1,)</versionRange>
-										<goals>
-											<goal>initialize-module</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-dependency-plugin</artifactId>
-										<versionRange>[2.4,)</versionRange>
-										<goals>
-											<goal>unpack-dependencies</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -23,7 +23,7 @@
 		${project.parent.description}
 	</description>
 	<updateURL>https://modules.openmrs.org/modules/download/${project.parent.artifactId}/update.rdf</updateURL>
-	<require_version>${openMRSVersion}</require_version>
+	<require_version>${openmrsPlatformVersion}</require_version>
 	<!-- / Module Properties -->
 
 	<aware_of_modules>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.openmrs.api</groupId>
+				<artifactId>openmrs-api</artifactId>
+				<version>${openmrsPlatformVersion}</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>idgen-api</artifactId>
 				<version>4.7.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>org.openmrs.maven.parents</groupId>
+		<artifactId>maven-parent-openmrs-module</artifactId>
+		<version>2.1.0</version>
+	</parent>
+
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>billing</artifactId>
 	<version>2.3.0-SNAPSHOT</version>
@@ -12,14 +18,14 @@
 
 	<distributionManagement>
 		<repository>
-			<id>openmrs-repo-modules</id>
-			<name>Modules</name>
-			<url>https://openmrs.jfrog.io/openmrs/modules/</url>
+			<id>openmrs-repo-releases</id>
+			<name>OpenMRS Releases</name>
+			<url>https://mavenrepo.openmrs.org/releases</url>
 		</repository>
 		<snapshotRepository>
 			<id>openmrs-repo-snapshots</id>
-			<name>Snapshots</name>
-			<url>https://openmrs.jfrog.io/openmrs/snapshots/</url>
+			<name>OpenMRS Snapshots</name>
+			<url>https://mavenrepo.openmrs.org/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -28,11 +34,6 @@
 			<name>OpenMRS</name>
 		</developer>
 	</developers>
-
-	<organization>
-		<name>OpenMRS</name>
-		<url>https://openmrs.org/</url>
-	</organization>
 
 	<scm>
 		<connection>scm:git:git@github.com:openmrs/openmrs-module-billing.git</connection>
@@ -48,11 +49,9 @@
 	</modules>
 
 	<properties>
-		<openMRSVersion>2.7.8</openMRSVersion>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<powermock.version>2.0.9</powermock.version>
-		<javaCompilerVersion>1.8</javaCompilerVersion>
-        <openmrsPlatformToolsVersion>2.4.0</openmrsPlatformToolsVersion>
+		<openmrsPlatformVersion>2.7.8</openmrsPlatformVersion>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<itextPdfVersion>8.0.2</itextPdfVersion>
 		<stockmanagementVersion>1.4.0</stockmanagementVersion>
 		<fhir2Version>2.4.0</fhir2Version>
@@ -63,48 +62,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-
-			<!-- Begin OpenMRS core -->
-			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.web</groupId>
-				<artifactId>openmrs-web</artifactId>
-				<version>${openMRSVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>test-jar</type>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.web</groupId>
-				<artifactId>openmrs-web</artifactId>
-				<version>${openMRSVersion}</version>
-				<classifier>tests</classifier>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.test</groupId>
-				<artifactId>openmrs-test</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>pom</type>
-				<scope>test</scope>
-			</dependency>
-
-			<!-- End OpenMRS core -->
-
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>idgen-api</artifactId>
@@ -124,8 +81,6 @@
 				<version>2.49.0</version>
 				<scope>provided</scope>
 			</dependency>
-
-			<!-- https://mvnrepository.com/artifact/com.google.common/google-collect -->
 
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
@@ -149,26 +104,26 @@
 				<scope>provided</scope>
 			</dependency>
 
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>fhir2-api-2.5</artifactId>
-                <version>${fhir2Version}</version>
-                <scope>provided</scope>
-            </dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>fhir2-api-2.5</artifactId>
+				<version>${fhir2Version}</version>
+				<scope>provided</scope>
+			</dependency>
 
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>fhir2-api-2.6</artifactId>
-                <version>${fhir2Version}</version>
-                <scope>provided</scope>
-            </dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>fhir2-api-2.6</artifactId>
+				<version>${fhir2Version}</version>
+				<scope>provided</scope>
+			</dependency>
 
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>fhir2-api-2.7</artifactId>
-                <version>${fhir2Version}</version>
-                <scope>provided</scope>
-            </dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>fhir2-api-2.7</artifactId>
+				<version>${fhir2Version}</version>
+				<scope>provided</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
@@ -236,7 +191,6 @@
 				<scope>provided</scope>
 			</dependency>
 
-			<!-- Depends on uiframework module -->
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>uiframework-api</artifactId>
@@ -266,7 +220,7 @@
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
-				<version>2.10.14</version> <!-- Replace with the latest version available -->
+				<version>2.10.14</version>
 			</dependency>
 
 			<dependency>
@@ -329,7 +283,6 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-			<!-- only needed for Asian fonts -->
 			<dependency>
 				<groupId>com.itextpdf</groupId>
 				<artifactId>font-asian</artifactId>
@@ -353,12 +306,12 @@
 				<scope>provided</scope>
 			</dependency>
 
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>3.12.4</version>
-                <scope>test</scope>
-            </dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-inline</artifactId>
+				<version>3.12.4</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -366,35 +319,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>net.revelc.code.formatter</groupId>
-					<artifactId>formatter-maven-plugin</artifactId>
-					<version>2.16.0</version>
-					<configuration>
-						<lineEnding>LF</lineEnding>
-						<configFile>eclipse/OpenMRSFormatter.xml</configFile>
-					</configuration>
-					<dependencies>
-						<dependency>
-							<groupId>org.openmrs.tools</groupId>
-							<artifactId>openmrs-tools</artifactId>
-							<version>${openmrsPlatformToolsVersion}</version>
-						</dependency>
-					</dependencies>
-					<executions>
-						<execution>
-							<goals>
-								<goal>format</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.15.0</version>
 					<configuration>
-						<target>${javaCompilerVersion}</target>
-						<source>${javaCompilerVersion}</source>
 						<annotationProcessorPaths>
 							<path>
 								<groupId>org.projectlombok</groupId>
@@ -405,14 +332,12 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.openmrs.maven.plugins</groupId>
-					<artifactId>maven-openmrs-plugin</artifactId>
-					<version>1.0.1</version>
-				</plugin>
-				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.5.0</version>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<configuration>
+						<doclint>none</doclint>
+						<failOnError>false</failOnError>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.liquibase</groupId>
@@ -429,36 +354,6 @@
 						<propertyFileWillOverride>true</propertyFileWillOverride>
 						<propertyFile>${basedir}/omod/target/classes/liquibase.properties</propertyFile>
 						<changeLogFile>${basedir}/omod/target/classes/liquibase.xml</changeLogFile>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-					<version>3.1.1</version>
-					<configuration>
-						<tagNameFormat>v@{project.version}</tagNameFormat>
-						<autoVersionSubmodules>true</autoVersionSubmodules>
-						<pushChanges>true</pushChanges>
-						<useReleaseProfile>false</useReleaseProfile>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M8</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.12.0</version>
-					<configuration>
-						<tags>
-							<tag>
-								<name>should</name>
-								<placement>a</placement>
-								<head>Should:</head>
-							</tag>
-						</tags>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -482,52 +377,25 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>net.revelc.code.formatter</groupId>
-				<artifactId>formatter-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
 	</build>
 
 	<repositories>
 		<repository>
 			<id>openmrs-repo</id>
-			<name>OpenMRS Nexus Repository</name>
-			<url>https://openmrs.jfrog.io/openmrs/public</url>
-		</repository>
-		<repository>
-			<id>openmrs-repo-snapshots</id>
-			<name>OpenMRS Snapshots Repository</name>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<url>https://openmrs.jfrog.io/openmrs/snapshots</url>
+			<name>OpenMRS Public</name>
+			<url>https://mavenrepo.openmrs.org/public</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>openmrs-repo</id>
-			<name>OpenMRS Nexus Repository</name>
-			<url>https://openmrs.jfrog.io/openmrs/public</url>
+			<name>OpenMRS Public</name>
+			<url>https://mavenrepo.openmrs.org/public</url>
 			<snapshots>
-				<enabled>false</enabled>
+				<enabled>true</enabled>
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-
-	<profiles>
-		<profile>
-			<id>openmrs-2.0</id>
-			<properties>
-				<openMRSVersion>2.0.5</openMRSVersion>
-				<javaCompilerVersion>1.8</javaCompilerVersion>
-			</properties>
-		</profile>
-	</profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openmrsPlatformVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>idgen-api</artifactId>
 				<version>4.7.0</version>


### PR DESCRIPTION
Inherits from the OpenMRS contrib maven parent so the module picks up the standard plugin versions, license/spotless wiring, and CI release profiles.

* Drop redundant pluginManagement for compiler, surefire, release, jar, openmrs-plugin, dependency-plugin, formatter-maven-plugin, and the m2e lifecycle-mapping. Drop the legacy `release` and `openmrs-2.0` profiles.
* Rename `openMRSVersion` -> `openmrsPlatformVersion` (the parent's dependencyManagement for openmrs-api/web/test is keyed off this name). Update omod/config.xml `<require_version>` to match.
* Switch maven.compiler.source/target from `1.8` to `8` and set as properties; the parent's enforcer regex `^([89]|[1-9]\d+)$` rejects `1.8`.
* Re-declare distributionManagement pointing at mavenrepo.openmrs.org in the child pom; the contrib GHA `infer_backend_params.py` reads it from the child only and does not follow parent inheritance.
* Re-declare repositories/pluginRepositories at mavenrepo.openmrs.org /public so Maven can resolve the parent POM itself.
* Configure javadoc with `<doclint>none</doclint>` and `<failOnError>false</failOnError>` so the parent's `ci`-profile javadoc step doesn't choke on legacy comments.
* In api/omod/fhir submodule poms, switch openmrs-api `<type>test-jar</type>` to `<classifier>tests</classifier>` to match the parent's dependencyManagement key. Drop formatter-maven-plugin references (the parent uses spotless instead).