### PR TITLE
O3-5422: Introduce a dedicated `BillLineItemStatus`

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/billing/impl/AbstractDefaultOrderBillingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/billing/impl/AbstractDefaultOrderBillingStrategy.java
@@ -34,6 +34,7 @@ import org.openmrs.module.billing.api.evaluator.ExemptionRuleEngine;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillExemption;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.ExemptionType;
@@ -168,11 +169,11 @@ public abstract class AbstractDefaultOrderBillingStrategy extends AbstractOrderB
 	 * Create a bill line item with the common fields populated. Subclasses should set the type-specific
 	 * fields (item or billable service) on the returned line item.
 	 */
-	protected BillLineItem createLineItem(BigDecimal price, int quantity, BillStatus paymentStatus, Order order) {
+	protected BillLineItem createLineItem(BigDecimal price, int quantity, BillLineItemStatus paymentStatus, Order order) {
 		BillLineItem lineItem = new BillLineItem();
 		lineItem.setPrice(price);
 		lineItem.setQuantity(quantity);
-		lineItem.setPaymentStatus(paymentStatus);
+		lineItem.setStatus(paymentStatus);
 		lineItem.setLineItemOrder(0);
 		lineItem.setOrder(order);
 		return lineItem;

--- a/api/src/main/java/org/openmrs/module/billing/api/billing/impl/DrugOrderBillingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/billing/impl/DrugOrderBillingStrategy.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 import org.openmrs.Provider;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.ItemPriceService;
 import org.openmrs.module.billing.api.model.BillLineItem;
@@ -64,7 +65,7 @@ public class DrugOrderBillingStrategy extends AbstractDefaultOrderBillingStrateg
 		
 		int quantity = (int) (drugOrder.getQuantity() != null ? drugOrder.getQuantity() : 0.0);
 		boolean isExempted = checkIfOrderIsExempted(order, ExemptionType.COMMODITY);
-		BillStatus lineItemStatus = isExempted ? BillStatus.EXEMPTED : BillStatus.PENDING;
+		BillLineItemStatus lineItemStatus = isExempted ? BillLineItemStatus.EXEMPTED : BillLineItemStatus.PENDING;
 		
 		StockItem stockItem = stockItems.get(0);
 		BillLineItem lineItem = createLineItem(resolvePrice(stockItem), quantity, lineItemStatus, order);

--- a/api/src/main/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategy.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmrs.Order;
 import org.openmrs.Provider;
 import org.openmrs.TestOrder;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.BillableServiceService;
 import org.openmrs.module.billing.api.ItemPriceService;
@@ -67,8 +68,9 @@ public class TestOrderBillingStrategy extends AbstractDefaultOrderBillingStrateg
 		}
 		
 		BillableService billableService = searchResult.get(0);
-		BillStatus lineItemStatus = checkIfOrderIsExempted(order, ExemptionType.SERVICE) ? BillStatus.EXEMPTED
-		        : BillStatus.PENDING;
+		BillLineItemStatus lineItemStatus = checkIfOrderIsExempted(order, ExemptionType.SERVICE)
+		        ? BillLineItemStatus.EXEMPTED
+		        : BillLineItemStatus.PENDING;
 		
 		BillLineItem lineItem = createLineItem(resolvePrice(billableService), 1, lineItemStatus, order);
 		lineItem.setBillableService(billableService);

--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/ImmutableBillLineItemInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/ImmutableBillLineItemInterceptor.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class ImmutableBillLineItemInterceptor extends ImmutableEntityInterceptor {
 	
 	private static final String[] MUTABLE_PROPERTY_NAMES = new String[] { "voided", "dateVoided", "voidedBy", "voidReason",
-	        "paymentStatus", "changedBy", "dateChanged" };
+	        "status", "changedBy", "dateChanged" };
 	
 	@Override
 	protected Class<?> getSupportedType() {

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillRefundService;
 import org.openmrs.module.billing.api.BillService;
@@ -29,6 +30,7 @@ import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.util.PrivilegeConstants;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 public class BillRefundServiceImpl implements BillRefundService {
 	
@@ -76,9 +78,12 @@ public class BillRefundServiceImpl implements BillRefundService {
 		BillRefund saved = billRefundDAO.saveBillRefund(billRefund);
 		stampTransitionTimestamps(saved);
 		Integer billId = saved.getBill() == null ? null : saved.getBill().getId();
+		if (billId == null) {
+			log.error("Saved refund {} has no associated bill; skipping status reconcile", saved.getUuid());
+		}
 		reconcileBillStatus(billId);
 		if (saved.getLineItem() != null) {
-			reconcileBillLineItemStatus(billId, saved.getLineItem().getId());
+			reconcileBillLineItemStatus(saved);
 		}
 		return saved;
 	}
@@ -108,6 +113,7 @@ public class BillRefundServiceImpl implements BillRefundService {
 			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
 			Bill freshBill = Context.getService(BillService.class).getBill(billId);
 			if (freshBill == null) {
+				log.error("Refund-driven reconcile could not load bill {}; bill status will not be updated", billId);
 				return;
 			}
 			BillStatus target = deriveBillStatusFromRefunds(billId, freshBill);
@@ -117,19 +123,29 @@ public class BillRefundServiceImpl implements BillRefundService {
 			freshBill.setStatus(target);
 			Context.getService(BillService.class).saveBill(freshBill);
 		}
+		catch (RuntimeException e) {
+			log.error("Failed to reconcile bill status for bill {}", billId, e);
+			throw e;
+		}
 		finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
 		}
 	}
 	
-	private void reconcileBillLineItemStatus(Integer billId, Integer billLineItemId) {
-		if (billLineItemId == null || billId == null) {
+	private void reconcileBillLineItemStatus(BillRefund refund) {
+		Integer billId = refund.getBill() == null ? null : refund.getBill().getId();
+		Integer billLineItemId = refund.getLineItem() == null ? null : refund.getLineItem().getId();
+		if (billId == null || billLineItemId == null) {
+			log.warn("Cannot reconcile line item status: refund {} has billId={} lineItemId={}", refund.getUuid(), billId,
+			    billLineItemId);
 			return;
 		}
 		try {
 			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
 			Bill freshBill = Context.getService(BillService.class).getBill(billId);
 			if (freshBill == null) {
+				log.error("Refund {} references bill {} which could not be loaded; skipping line-item status reconcile",
+				    refund.getUuid(), billId);
 				return;
 			}
 			
@@ -137,6 +153,8 @@ public class BillRefundServiceImpl implements BillRefundService {
 			        .findFirst().orElse(null);
 			
 			if (lineItem == null) {
+				log.error("Refund {} references line item {} that is not on bill {}; skipping line-item status reconcile",
+				    refund.getUuid(), billLineItemId, billId);
 				return;
 			}
 			
@@ -146,6 +164,11 @@ public class BillRefundServiceImpl implements BillRefundService {
 			}
 			lineItem.setStatus(target);
 			Context.getService(BillService.class).saveBill(freshBill);
+		}
+		catch (RuntimeException e) {
+			log.error("Failed to reconcile line item {} on bill {} for refund {}", billLineItemId, billId, refund.getUuid(),
+			    e);
+			throw e;
 		}
 		finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
@@ -136,7 +136,7 @@ public class BillRefundServiceImpl implements BillRefundService {
 		Integer billId = refund.getBill() == null ? null : refund.getBill().getId();
 		Integer billLineItemId = refund.getLineItem() == null ? null : refund.getLineItem().getId();
 		if (billId == null || billLineItemId == null) {
-			log.warn("Cannot reconcile line item status: refund {} has billId={} lineItemId={}", refund.getUuid(), billId,
+			log.error("Cannot reconcile line item status: refund {} has billId={} lineItemId={}", refund.getUuid(), billId,
 			    billLineItemId);
 			return;
 		}

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
@@ -12,6 +12,8 @@ package org.openmrs.module.billing.api.impl;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.openmrs.api.context.Context;
@@ -19,6 +21,8 @@ import org.openmrs.module.billing.api.BillRefundService;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.db.BillRefundDAO;
 import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.RefundStatus;
@@ -72,6 +76,9 @@ public class BillRefundServiceImpl implements BillRefundService {
 		BillRefund saved = billRefundDAO.saveBillRefund(billRefund);
 		stampTransitionTimestamps(saved);
 		reconcileBillStatus(saved.getBill() == null ? null : saved.getBill().getId());
+		if (saved.getLineItem() != null) {
+			reconcileBillLineItemStatus(saved.getBill().getBillId(), saved.getLineItem().getId());
+		}
 		return saved;
 	}
 	
@@ -96,8 +103,8 @@ public class BillRefundServiceImpl implements BillRefundService {
 		if (billId == null) {
 			return;
 		}
-		Context.addProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
 		try {
+			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
 			Bill freshBill = Context.getService(BillService.class).getBill(billId);
 			if (freshBill == null) {
 				return;
@@ -107,6 +114,36 @@ public class BillRefundServiceImpl implements BillRefundService {
 				return;
 			}
 			freshBill.setStatus(target);
+			Context.getService(BillService.class).saveBill(freshBill);
+		}
+		finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
+		}
+	}
+	
+	private void reconcileBillLineItemStatus(Integer billId, Integer billLineItemId) {
+		if (billLineItemId == null || billId == null) {
+			return;
+		}
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_BILLS);
+			Bill freshBill = Context.getService(BillService.class).getBill(billId);
+			if (freshBill == null) {
+				return;
+			}
+			
+			BillLineItem lineItem = freshBill.getLineItems().stream().filter(li -> li.getId().equals(billLineItemId))
+			        .findFirst().orElse(null);
+			
+			if (lineItem == null) {
+				return;
+			}
+			
+			BillLineItemStatus target = deriveBillLineItemStatusFromRefunds(billId, lineItem);
+			if (lineItem.getStatus() == target) {
+				return;
+			}
+			lineItem.setStatus(target);
 			Context.getService(BillService.class).saveBill(freshBill);
 		}
 		finally {
@@ -124,7 +161,7 @@ public class BillRefundServiceImpl implements BillRefundService {
 		
 		BigDecimal totalRefunded = history.stream()
 		        .filter(r -> r.getStatus() == RefundStatus.APPROVED || r.getStatus() == RefundStatus.COMPLETED)
-		        .map(BillRefund::getRefundAmount).filter(a -> a != null).reduce(BigDecimal.ZERO, BigDecimal::add);
+		        .map(BillRefund::getRefundAmount).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
 		
 		if (totalRefunded.compareTo(BigDecimal.ZERO) == 0) {
 			return BillStatus.PAID;
@@ -135,4 +172,29 @@ public class BillRefundServiceImpl implements BillRefundService {
 		}
 		return BillStatus.PARTIALLY_REFUNDED;
 	}
+	
+	private BillLineItemStatus deriveBillLineItemStatusFromRefunds(Integer billId, BillLineItem lineItem) {
+		List<BillRefund> history = billRefundDAO.getRefundsByBillId(billId).stream()
+		        .filter(r -> !Boolean.TRUE.equals(r.getVoided()))
+		        .filter(r -> r.getLineItem() != null && lineItem.getId().equals(r.getLineItem().getId()))
+		        .collect(Collectors.toList());
+		
+		if (history.stream().anyMatch(r -> r.getStatus() == RefundStatus.REQUESTED)) {
+			return BillLineItemStatus.REFUND_REQUESTED;
+		}
+		
+		BigDecimal totalRefunded = history.stream()
+		        .filter(r -> r.getStatus() == RefundStatus.APPROVED || r.getStatus() == RefundStatus.COMPLETED)
+		        .map(BillRefund::getRefundAmount).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
+		
+		if (totalRefunded.compareTo(BigDecimal.ZERO) == 0) {
+			return BillLineItemStatus.PAID;
+		}
+		BigDecimal lineTotal = lineItem.getTotal();
+		if (lineTotal != null && totalRefunded.compareTo(lineTotal) >= 0) {
+			return BillLineItemStatus.REFUNDED;
+		}
+		return BillLineItemStatus.PARTIALLY_REFUNDED;
+	}
+	
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/BillRefundServiceImpl.java
@@ -75,9 +75,10 @@ public class BillRefundServiceImpl implements BillRefundService {
 	public BillRefund saveBillRefund(BillRefund billRefund) {
 		BillRefund saved = billRefundDAO.saveBillRefund(billRefund);
 		stampTransitionTimestamps(saved);
-		reconcileBillStatus(saved.getBill() == null ? null : saved.getBill().getId());
+		Integer billId = saved.getBill() == null ? null : saved.getBill().getId();
+		reconcileBillStatus(billId);
 		if (saved.getLineItem() != null) {
-			reconcileBillLineItemStatus(saved.getBill().getBillId(), saved.getLineItem().getId());
+			reconcileBillLineItemStatus(billId, saved.getLineItem().getId());
 		}
 		return saved;
 	}

--- a/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
@@ -249,11 +249,11 @@ public class Bill extends BaseOpenmrsData {
 			boolean billFullySettled = getTotalPayments().compareTo(getAmountAfterDiscount()) >= 0;
 			if (billFullySettled) {
 				this.setStatus(BillStatus.PAID);
-				// Update all non-voided bill line items to PAID status
+				// Update all non-voided and non-refunded status bill line items to PAID status
 				if (this.lineItems != null) {
 					for (BillLineItem lineItem : this.lineItems) {
-						if (lineItem != null && !lineItem.getVoided()) {
-							lineItem.setPaymentStatus(BillStatus.PAID);
+						if (lineItem != null && !lineItem.getVoided() && !isRefundStatus(lineItem.getStatus())) {
+							lineItem.setStatus(BillLineItemStatus.PAID);
 						}
 					}
 				}
@@ -305,6 +305,11 @@ public class Bill extends BaseOpenmrsData {
 		for (BillLineItem lineItem : this.getLineItems()) {
 			lineItem.setLineItemOrder(orderCounter++);
 		}
+	}
+	
+	private boolean isRefundStatus(BillLineItemStatus lineItemStatus) {
+		return lineItemStatus == BillLineItemStatus.REFUND_REQUESTED || lineItemStatus == BillLineItemStatus.REFUNDED
+		        || lineItemStatus == BillLineItemStatus.PARTIALLY_REFUNDED;
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
@@ -11,6 +11,8 @@ package org.openmrs.module.billing.api.model;
 
 import java.math.BigDecimal;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.openmrs.BaseChangeableOpenmrsData;
 import org.openmrs.Order;
 import org.openmrs.module.stockmanagement.api.model.StockItem;
@@ -19,6 +21,8 @@ import org.openmrs.module.stockmanagement.api.model.StockItem;
  * A LineItem represents a line on a {@link Bill} which will bill some quantity of a particular
  * {@link StockItem}.
  */
+@Setter
+@Getter
 public class BillLineItem extends BaseChangeableOpenmrsData {
 	
 	private static final long serialVersionUID = 0L;
@@ -41,8 +45,7 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 	
 	private Integer lineItemOrder;
 	
-	private BillStatus paymentStatus; // this should only be set to either
-	// pending or paid
+	private BillLineItemStatus status;
 	
 	private Order order;
 	
@@ -65,83 +68,4 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 		return price.multiply(BigDecimal.valueOf(quantity));
 	}
 	
-	public CashierItemPrice getItemPrice() {
-		return itemPrice;
-	}
-	
-	public void setItemPrice(CashierItemPrice itemPrice) {
-		this.itemPrice = itemPrice;
-	}
-	
-	public BillableService getBillableService() {
-		return billableService;
-	}
-	
-	public void setBillableService(BillableService billableService) {
-		this.billableService = billableService;
-	}
-	
-	public Integer getQuantity() {
-		return quantity;
-	}
-	
-	public void setQuantity(Integer quantity) {
-		this.quantity = quantity;
-	}
-	
-	public Bill getBill() {
-		return bill;
-	}
-	
-	public void setBill(Bill bill) {
-		this.bill = bill;
-	}
-	
-	public StockItem getItem() {
-		return item;
-	}
-	
-	public void setItem(StockItem item) {
-		this.item = item;
-	}
-	
-	public BigDecimal getPrice() {
-		return price;
-	}
-	
-	public void setPrice(BigDecimal price) {
-		this.price = price;
-	}
-	
-	public String getPriceName() {
-		return priceName;
-	}
-	
-	public void setPriceName(String priceName) {
-		this.priceName = priceName;
-	}
-	
-	public Integer getLineItemOrder() {
-		return lineItemOrder;
-	}
-	
-	public void setLineItemOrder(Integer lineItemOrder) {
-		this.lineItemOrder = lineItemOrder;
-	}
-	
-	public BillStatus getPaymentStatus() {
-		return paymentStatus;
-	}
-	
-	public void setPaymentStatus(BillStatus paymentStatus) {
-		this.paymentStatus = paymentStatus;
-	}
-	
-	public Order getOrder() {
-		return order;
-	}
-	
-	public void setOrder(Order order) {
-		this.order = order;
-	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItem.java
@@ -11,6 +11,7 @@ package org.openmrs.module.billing.api.model;
 
 import java.math.BigDecimal;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.openmrs.BaseChangeableOpenmrsData;
@@ -27,6 +28,7 @@ public class BillLineItem extends BaseChangeableOpenmrsData {
 	
 	private static final long serialVersionUID = 0L;
 	
+	@Setter(AccessLevel.NONE)
 	private Integer billLineItemId;
 	
 	private Bill bill;

--- a/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItemStatus.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/BillLineItemStatus.java
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.model;
+
+public enum BillLineItemStatus {
+	PENDING,
+	PAID,
+	CANCELLED,
+	ADJUSTED,
+	EXEMPTED,
+	REFUND_REQUESTED,
+	REFUNDED,
+	PARTIALLY_REFUNDED;
+}

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -182,9 +182,9 @@
 		<property name="priceName" type="java.lang.String" column="price_name" length="255"/>
 		<property name="quantity" type="int" column="quantity" not-null="true"/>
 		<property name="lineItemOrder" type="int" column="line_item_order"/>
-		<property name="paymentStatus" column="payment_status" not-null="true">
+		<property name="status" column="status" not-null="true">
 			<type name="org.hibernate.type.EnumType">
-				<param name="enumClass">org.openmrs.module.billing.api.model.BillStatus</param>
+				<param name="enumClass">org.openmrs.module.billing.api.model.BillLineItemStatus</param>
 				<param name="type">12</param>
 			</type>
 		</property>

--- a/api/src/test/java/org/openmrs/module/billing/api/BillLineItemServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/BillLineItemServiceTest.java
@@ -34,6 +34,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
@@ -139,7 +140,7 @@ public class BillLineItemServiceTest extends BaseModuleContextSensitiveTest {
 		BillLineItem lineItem = new BillLineItem();
 		lineItem.setPrice(new BigDecimal("100.00"));
 		lineItem.setQuantity(1);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setStatus(BillLineItemStatus.PENDING);
 		lineItem.setLineItemOrder(0);
 		
 		Bill bill = new Bill();
@@ -158,7 +159,7 @@ public class BillLineItemServiceTest extends BaseModuleContextSensitiveTest {
 		BillLineItem lineItem = new BillLineItem();
 		lineItem.setPrice(new BigDecimal("75.00"));
 		lineItem.setQuantity(1);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setStatus(BillLineItemStatus.PENDING);
 		lineItem.setLineItemOrder(0);
 		lineItem.setOrder(order);
 		

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/OrderBillingEventListenerTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/OrderBillingEventListenerTest.java
@@ -36,6 +36,7 @@ import org.openmrs.module.billing.api.BillLineItemService;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
@@ -94,7 +95,7 @@ public class OrderBillingEventListenerTest extends BaseModuleContextSensitiveTes
 		assertFalse(bill.getLineItems().isEmpty());
 		BillLineItem lineItem = bill.getLineItems().get(0);
 		assertNotNull(lineItem.getBillableService());
-		assertEquals(BillStatus.PENDING, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PENDING, lineItem.getStatus());
 		assertEquals(1, lineItem.getQuantity());
 		assertEquals(new BigDecimal("75.00"), lineItem.getPrice());
 		assertEquals(savedOrder.getId(), lineItem.getOrder().getId());
@@ -305,7 +306,7 @@ public class OrderBillingEventListenerTest extends BaseModuleContextSensitiveTes
 		
 		BillLineItem lineItem = bill.getLineItems().get(0);
 		assertNotNull(lineItem.getItem(), "Line item should reference a stock item");
-		assertEquals(BillStatus.PENDING, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PENDING, lineItem.getStatus());
 		assertEquals(5, lineItem.getQuantity());
 		assertEquals(new BigDecimal("150.00"), lineItem.getPrice());
 		assertEquals(savedOrder.getId(), lineItem.getOrder().getId());

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/DrugOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/DrugOrderBillingStrategyTest.java
@@ -11,9 +11,7 @@ package org.openmrs.module.billing.api.billing.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -29,12 +27,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.Concept;
 import org.openmrs.Drug;
 import org.openmrs.DrugOrder;
-import org.openmrs.Order;
 import org.openmrs.TestOrder;
 import org.openmrs.module.billing.api.BillExemptionService;
 import org.openmrs.module.billing.api.ItemPriceService;
 import org.openmrs.module.billing.api.model.BillLineItem;
-import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.CashierItemPrice;
 import org.openmrs.module.stockmanagement.api.StockManagementService;
 import org.openmrs.module.stockmanagement.api.model.StockItem;
@@ -100,7 +97,7 @@ public class DrugOrderBillingStrategyTest {
 		BillLineItem lineItem = result.get();
 		assertEquals(new BigDecimal("200.00"), lineItem.getPrice());
 		assertEquals(5, lineItem.getQuantity());
-		assertEquals(BillStatus.PENDING, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PENDING, lineItem.getStatus());
 		assertEquals(stockItem, lineItem.getItem());
 	}
 	

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -11,7 +11,6 @@ package org.openmrs.module.billing.api.billing.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -29,13 +28,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.Concept;
 import org.openmrs.DrugOrder;
-import org.openmrs.Order;
 import org.openmrs.TestOrder;
 import org.openmrs.module.billing.api.BillExemptionService;
 import org.openmrs.module.billing.api.BillableServiceService;
 import org.openmrs.module.billing.api.ItemPriceService;
 import org.openmrs.module.billing.api.model.BillLineItem;
-import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillableService;
 import org.openmrs.module.billing.api.model.CashierItemPrice;
 import org.openmrs.module.billing.api.search.BillableServiceSearch;
@@ -99,7 +97,7 @@ public class TestOrderBillingStrategyTest {
 		BillLineItem lineItem = result.get();
 		assertEquals(new BigDecimal("75.00"), lineItem.getPrice());
 		assertEquals(1, lineItem.getQuantity());
-		assertEquals(BillStatus.PENDING, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PENDING, lineItem.getStatus());
 		assertEquals(billableService, lineItem.getBillableService());
 	}
 	

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/BillRefundServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/BillRefundServiceImplTest.java
@@ -19,6 +19,7 @@ import org.openmrs.module.billing.api.BillRefundService;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.RefundStatus;
@@ -37,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BillRefundServiceImplTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String CLEAN_PAID_BILL_UUID = "r0000000-0000-0000-0000-000000000300";
+	
+	private static final String CLEAN_PAID_LINE_ITEM_UUID = "r0000000-0000-0000-0000-000000000310";
 	
 	private static final String MULTILINE_PAID_BILL_UUID = "r0000000-0000-0000-0000-000000000301";
 	
@@ -520,6 +523,77 @@ public class BillRefundServiceImplTest extends BaseModuleContextSensitiveTest {
 		
 		assertNotNull(saved);
 		assertEquals("Updated reason", saved.getReason());
+	}
+	
+	@Test
+	public void saveBillRefund_shouldFlipLineItemToRefundRequestedOnCreate() {
+		BillRefund refund = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("30.00"), "Partial line refund");
+		
+		service.saveBillRefund(refund);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.REFUND_REQUESTED, lineItem.getStatus());
+	}
+	
+	@Test
+	public void saveBillRefund_shouldFlipLineItemToPartiallyRefundedOnApprovingPartialLineRefund() {
+		BillRefund refund = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("30.00"), "Partial line refund");
+		BillRefund saved = service.saveBillRefund(refund);
+		
+		saved.setStatus(RefundStatus.APPROVED);
+		saved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(saved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.PARTIALLY_REFUNDED, lineItem.getStatus());
+	}
+	
+	@Test
+	public void saveBillRefund_shouldFlipLineItemToRefundedOnApprovingFullLineAmount() {
+		BillRefund refund = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("60.00"), "Full line refund");
+		BillRefund saved = service.saveBillRefund(refund);
+		
+		saved.setStatus(RefundStatus.APPROVED);
+		saved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(saved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.REFUNDED, lineItem.getStatus());
+	}
+	
+	@Test
+	public void saveBillRefund_shouldRevertLineItemToPaidWhenApprovedLineScopedRefundIsVoided() {
+		BillRefund refund = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("60.00"), "Full line refund");
+		BillRefund saved = service.saveBillRefund(refund);
+		
+		saved.setStatus(RefundStatus.APPROVED);
+		saved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(saved);
+		
+		BillRefund approved = service.getBillRefundByUuid(saved.getUuid());
+		approved.setVoided(true);
+		approved.setVoidReason("Mistakenly raised");
+		service.saveBillRefund(approved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.PAID, lineItem.getStatus());
+	}
+	
+	@Test
+	public void saveBillRefund_billScopedRefundShouldNotChangeLineItemStatus() {
+		BillRefund refund = buildRefund(CLEAN_PAID_BILL_UUID, new BigDecimal("40.00"), "Partial bill-level refund");
+		BillRefund saved = service.saveBillRefund(refund);
+		
+		saved.setStatus(RefundStatus.APPROVED);
+		saved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(saved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(CLEAN_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.PAID, lineItem.getStatus());
 	}
 	
 	private BillRefund buildRefund(String billUuid, BigDecimal amount, String reason) {

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/BillRefundServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/BillRefundServiceImplTest.java
@@ -584,6 +584,45 @@ public class BillRefundServiceImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
+	public void saveBillRefund_shouldFlipLineItemToRefundedWhenCumulativeApprovedRefundsReachLineTotal() {
+		// Proves the derivation sums across multiple line-scoped refunds rather than only inspecting the latest.
+		BillRefund first = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("25.00"), "First partial");
+		BillRefund firstSaved = service.saveBillRefund(first);
+		firstSaved.setStatus(RefundStatus.APPROVED);
+		firstSaved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(firstSaved);
+		BillRefund firstApproved = service.getBillRefundByUuid(firstSaved.getUuid());
+		firstApproved.setStatus(RefundStatus.COMPLETED);
+		firstApproved.setCompleter(Context.getUserService().getUser(5506));
+		service.saveBillRefund(firstApproved);
+		
+		BillRefund second = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("35.00"), "Second partial bringing total to line price");
+		BillRefund secondSaved = service.saveBillRefund(second);
+		secondSaved.setStatus(RefundStatus.APPROVED);
+		secondSaved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(secondSaved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.REFUNDED, lineItem.getStatus());
+	}
+	
+	@Test
+	public void saveBillRefund_shouldRevertLineItemToPaidWhenLineScopedRefundIsRejected() {
+		BillRefund refund = buildLineScopedRefund(MULTILINE_PAID_BILL_UUID, MULTILINE_PAID_LINE_ITEM_UUID,
+		    new BigDecimal("30.00"), "Line refund to be rejected");
+		BillRefund saved = service.saveBillRefund(refund);
+		
+		saved.setStatus(RefundStatus.REJECTED);
+		saved.setApprover(Context.getUserService().getUser(5506));
+		service.saveBillRefund(saved);
+		
+		BillLineItem lineItem = lineItemService.getBillLineItemByUuid(MULTILINE_PAID_LINE_ITEM_UUID);
+		assertEquals(BillLineItemStatus.PAID, lineItem.getStatus());
+	}
+	
+	@Test
 	public void saveBillRefund_billScopedRefundShouldNotChangeLineItemStatus() {
 		BillRefund refund = buildRefund(CLEAN_PAID_BILL_UUID, new BigDecimal("40.00"), "Partial bill-level refund");
 		BillRefund saved = service.saveBillRefund(refund);

--- a/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
@@ -228,6 +228,56 @@ public class BillTest {
 	}
 	
 	@Test
+	public void synchronizeBillStatus_shouldNotClobberRefundStateLineItemsWhenBillIsFullyPaid() {
+		// Line items that already reflect a refund state must not be flipped back to PAID
+		// when the bill is settled. This guards against a partial-payment + refund interleave
+		// silently dropping line-level refund history.
+		Bill bill = new Bill();
+		bill.setLineItems(new ArrayList<>());
+		bill.setPayments(new HashSet<>());
+		
+		BillLineItem paidLine = new BillLineItem();
+		paidLine.setPrice(BigDecimal.valueOf(40));
+		paidLine.setQuantity(1);
+		paidLine.setVoided(false);
+		bill.getLineItems().add(paidLine);
+		
+		BillLineItem refundRequestedLine = new BillLineItem();
+		refundRequestedLine.setPrice(BigDecimal.valueOf(20));
+		refundRequestedLine.setQuantity(1);
+		refundRequestedLine.setVoided(false);
+		refundRequestedLine.setStatus(BillLineItemStatus.REFUND_REQUESTED);
+		bill.getLineItems().add(refundRequestedLine);
+		
+		BillLineItem partiallyRefundedLine = new BillLineItem();
+		partiallyRefundedLine.setPrice(BigDecimal.valueOf(25));
+		partiallyRefundedLine.setQuantity(1);
+		partiallyRefundedLine.setVoided(false);
+		partiallyRefundedLine.setStatus(BillLineItemStatus.PARTIALLY_REFUNDED);
+		bill.getLineItems().add(partiallyRefundedLine);
+		
+		BillLineItem refundedLine = new BillLineItem();
+		refundedLine.setPrice(BigDecimal.valueOf(15));
+		refundedLine.setQuantity(1);
+		refundedLine.setVoided(false);
+		refundedLine.setStatus(BillLineItemStatus.REFUNDED);
+		bill.getLineItems().add(refundedLine);
+		
+		Payment payment = new Payment();
+		payment.setAmountTendered(BigDecimal.valueOf(100));
+		payment.setVoided(false);
+		bill.getPayments().add(payment);
+		
+		bill.synchronizeBillStatus();
+		
+		assertEquals(BillStatus.PAID, bill.getStatus());
+		assertEquals(BillLineItemStatus.PAID, paidLine.getStatus());
+		assertEquals(BillLineItemStatus.REFUND_REQUESTED, refundRequestedLine.getStatus());
+		assertEquals(BillLineItemStatus.PARTIALLY_REFUNDED, partiallyRefundedLine.getStatus());
+		assertEquals(BillLineItemStatus.REFUNDED, refundedLine.getStatus());
+	}
+	
+	@Test
 	public void synchronizeBillStatus_shouldFlipToPaidWhenPaymentEqualsAmountAfterDiscount() {
 		// Gross total 100, discount 30 → discounted total 70. Payment of 70 must mark the bill PAID
 		// even though the gross total is still 100. This is the behavior synchronizeBillStatus()

--- a/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/model/BillTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 
 import org.junit.Test;
-import org.openmrs.module.billing.api.model.DiscountStatus;
 
 /**
  * Test for verifying Bill model methods, particularly getTotalPayments()
@@ -131,7 +130,7 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		
 		assertEquals(BillStatus.PAID, bill.getStatus());
-		assertEquals(BillStatus.PAID, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem.getStatus());
 	}
 	
 	@Test
@@ -187,7 +186,7 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		assertEquals(BillStatus.PAID, bill.getStatus());
 		// Only non-voided line items should be set to PAID
-		assertEquals(BillStatus.PAID, lineItem1.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem1.getStatus());
 	}
 	
 	@Test
@@ -222,10 +221,10 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		
 		assertEquals(BillStatus.PAID, bill.getStatus());
-		assertEquals(BillStatus.PAID, lineItem1.getPaymentStatus());
-		assertEquals(BillStatus.PAID, lineItem2.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem1.getStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem2.getStatus());
 		// Voided line items should not be updated
-		assertNull(voidedLineItem.getPaymentStatus());
+		assertNull(voidedLineItem.getStatus());
 	}
 	
 	@Test
@@ -259,7 +258,7 @@ public class BillTest {
 		bill.synchronizeBillStatus();
 		
 		assertEquals(BillStatus.PAID, bill.getStatus());
-		assertEquals(BillStatus.PAID, lineItem.getPaymentStatus());
+		assertEquals(BillLineItemStatus.PAID, lineItem.getStatus());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -28,6 +28,7 @@ import org.openmrs.module.billing.api.PaymentModeService;
 import org.openmrs.module.billing.api.base.PagingInfo;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.Payment;
 import org.openmrs.module.billing.api.model.PaymentMode;
@@ -143,7 +144,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		StockItem stockItem = existingItem.getItem();
 		
 		BillLineItem lineItem = newBill.addLineItem(stockItem, BigDecimal.valueOf(150), "New price", 2);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setStatus(BillLineItemStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
 		Bill savedBill = billService.saveBill(newBill);
@@ -222,7 +223,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BillLineItem newLineItem = new BillLineItem();
 		newLineItem.setPrice(BigDecimal.valueOf(25.50));
 		newLineItem.setQuantity(2);
-		newLineItem.setPaymentStatus(BillStatus.PENDING);
+		newLineItem.setStatus(BillLineItemStatus.PENDING);
 		newLineItem.setLineItemOrder(pendingBill.getLineItems().size());
 		pendingBill.addLineItem(newLineItem);
 		
@@ -246,7 +247,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		BillLineItem newLineItem = new BillLineItem();
 		newLineItem.setPrice(BigDecimal.valueOf(25.50));
 		newLineItem.setQuantity(2);
-		newLineItem.setPaymentStatus(BillStatus.PENDING);
+		newLineItem.setStatus(BillLineItemStatus.PENDING);
 		paidBill.addLineItem(newLineItem);
 		
 		// Should throw exception when saving (BillValidator catches line item
@@ -495,7 +496,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		Bill templateBill = billService.getBill(0);
 		BillLineItem existingItem = templateBill.getLineItems().get(0);
 		BillLineItem lineItem = newBill.addLineItem(existingItem.getItem(), BigDecimal.valueOf(100), "Test price", 1);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setStatus(BillLineItemStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
 		Bill savedBill = billService.saveBill(newBill);

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillDiscountStatusFilterTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillDiscountStatusFilterTest.xml
@@ -21,7 +21,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="b1000000-0000-0000-0000-000000000001" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="1010" bill_id="1001" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001010"/>
 
@@ -31,7 +31,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="b2000000-0000-0000-0000-000000000002" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="1020" bill_id="1002" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001020"/>
 
@@ -41,7 +41,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="b3000000-0000-0000-0000-000000000003" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="1030" bill_id="1003" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001030"/>
 
@@ -51,11 +51,11 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="b4000000-0000-0000-0000-000000000004" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="1040" bill_id="1004" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001040"/>
 	<cashier_bill_line_item bill_line_item_id="1041" bill_id="1004" item_id="0" price="50.00" price_name="default"
-	                        quantity="1" line_item_order="1" payment_status="PENDING"
+	                        quantity="1" line_item_order="1" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001041"/>
 
@@ -65,7 +65,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="b5000000-0000-0000-0000-000000000005" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="1050" bill_id="1005" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="e1000000-0000-0000-0000-000000001050"/>
 

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillDiscountTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillDiscountTest.xml
@@ -25,11 +25,11 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="d0000000-0000-0000-0000-000000000100" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="100" bill_id="100" item_id="0" price="200.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="POSTED"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="d0000000-0000-0000-0000-000000000110"/>
 	<cashier_bill_line_item bill_line_item_id="102" bill_id="100" item_id="0" price="80.00" price_name="default"
-	                        quantity="1" line_item_order="1" payment_status="POSTED"
+	                        quantity="1" line_item_order="1" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="d0000000-0000-0000-0000-000000000112"/>
 
@@ -39,7 +39,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="d0000000-0000-0000-0000-000000000101" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="101" bill_id="101" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="d0000000-0000-0000-0000-000000000111"/>
 
@@ -49,7 +49,7 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="d0000000-0000-0000-0000-000000000200" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="200" bill_id="200" item_id="0" price="200.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="POSTED"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="d0000000-0000-0000-0000-000000000210"/>
 

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillRefundTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillRefundTest.xml
@@ -21,7 +21,7 @@
 	              creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	              uuid="r0000000-0000-0000-0000-000000000300" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="300" bill_id="300" item_id="0" price="100.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000310"/>
 
@@ -31,11 +31,11 @@
 	              creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	              uuid="r0000000-0000-0000-0000-000000000301" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="301" bill_id="301" item_id="0" price="60.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000311"/>
 	<cashier_bill_line_item bill_line_item_id="302" bill_id="301" item_id="0" price="40.00" price_name="default"
-	                        quantity="1" line_item_order="1" payment_status="PAID"
+	                        quantity="1" line_item_order="1" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000312"/>
 
@@ -45,7 +45,7 @@
 	              creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	              uuid="r0000000-0000-0000-0000-000000000302" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="320" bill_id="302" item_id="0" price="50.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000320"/>
 
@@ -55,11 +55,11 @@
 	              creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	              uuid="r0000000-0000-0000-0000-000000000303" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="330" bill_id="303" item_id="0" price="70.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000330"/>
 	<cashier_bill_line_item bill_line_item_id="331" bill_id="303" item_id="0" price="30.00" price_name="default"
-	                        quantity="1" line_item_order="1" payment_status="PAID"
+	                        quantity="1" line_item_order="1" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000331"/>
 
@@ -80,7 +80,7 @@
 	              creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	              uuid="r0000000-0000-0000-0000-000000000304" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="340" bill_id="304" item_id="0" price="40.00" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-04-01 00:00:00.0" voided="false"
 	                        uuid="r0000000-0000-0000-0000-000000000340"/>
 	<bill_refund bill_refund_id="2" bill_id="304" refund_amount="40.00" reason="Mistakenly raised"

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillTest.xml
@@ -42,15 +42,15 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="4028814B39B565A20139B95D74360004" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="0" bill_id="0" item_id="0" price="101.01" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B95FB3440005"/>
 	<cashier_bill_line_item bill_line_item_id="1" bill_id="0" item_id="1" price="202.01" price_name="test 2 price"
-	                        quantity="3" line_item_order="1" payment_status="PAID"
+	                        quantity="3" line_item_order="1" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B963B13B0006"/>
 	<cashier_bill_line_item bill_line_item_id="2" bill_id="0" item_id="2" price="103.01" price_name="default"
-	                        quantity="2" line_item_order="2" payment_status="PAID"
+	                        quantity="2" line_item_order="2" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B9645D7B0007"/>
 	<cashier_bill_payment bill_payment_id="0" bill_id="0" payment_mode_id="0" amount="913.06" amount_tendered="1000.00"
@@ -66,7 +66,7 @@
 	              creator="1" date_created="2012-02-01 00:00:00.0" voided="false"
 	              uuid="5028814B39B565A20139B95D74360004" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="3" bill_id="1" item_id="0" price="150.00" price_name="default"
-	                        quantity="2" line_item_order="0" payment_status="PAID"
+	                        quantity="2" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-02-01 00:00:00.0" voided="false"
 	                        uuid="5028814B39B565A20139B95FB3440005"/>
 	<cashier_bill_payment bill_payment_id="1" bill_id="1" payment_mode_id="0" amount="300.00" amount_tendered="300.00"
@@ -78,11 +78,11 @@
 	              creator="1" date_created="2012-03-01 00:00:00.0" voided="false"
 	              uuid="6028814B39B565A20139B95D74360004" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="4" bill_id="2" item_id="1" price="75.50" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PENDING"
+	                        quantity="1" line_item_order="0" status="PENDING"
 	                        creator="1" date_created="2012-03-01 00:00:00.0" voided="false"
 	                        uuid="6028814B39B565A20139B95FB3440005"/>
 	<cashier_bill_line_item bill_line_item_id="5" bill_id="2" item_id="2" price="50.00" price_name="default"
-	                        quantity="1" line_item_order="1" payment_status="PENDING"
+	                        quantity="1" line_item_order="1" status="PENDING"
 	                        creator="1" date_created="2012-03-01 00:00:00.0" voided="false"
 	                        uuid="6028814B39B565A20139B95FB3440006"/>
 </dataset>

--- a/fhir/src/test/resources/org/openmrs/module/billing/include/BillTest.xml
+++ b/fhir/src/test/resources/org/openmrs/module/billing/include/BillTest.xml
@@ -42,15 +42,15 @@
 	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	              uuid="4028814B39B565A20139B95D74360004" receipt_printed="0"/>
 	<cashier_bill_line_item bill_line_item_id="0" bill_id="0" item_id="0" price="101.01" price_name="default"
-	                        quantity="1" line_item_order="0" payment_status="PAID"
+	                        quantity="1" line_item_order="0" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B95FB3440005"/>
 	<cashier_bill_line_item bill_line_item_id="1" bill_id="0" item_id="1" price="202.01" price_name="test 2 price"
-	                        quantity="3" line_item_order="1" payment_status="PAID"
+	                        quantity="3" line_item_order="1" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B963B13B0006"/>
 	<cashier_bill_line_item bill_line_item_id="2" bill_id="0" item_id="2" price="103.01" price_name="default"
-	                        quantity="2" line_item_order="2" payment_status="PAID"
+	                        quantity="2" line_item_order="2" status="PAID"
 	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
 	                        uuid="4028814B39B565A20139B9645D7B0007"/>
 	<cashier_bill_payment bill_payment_id="0" bill_id="0" payment_mode_id="0" amount="913.06" amount_tendered="1000.00"

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillLineItemResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillLineItemResource.java
@@ -55,7 +55,7 @@ public class BillLineItemResource extends BaseRestDataResource<BillLineItem> {
 			description.addProperty("priceName");
 			description.addProperty("priceUuid");
 			description.addProperty("lineItemOrder");
-			description.addProperty("paymentStatus");
+			description.addProperty("status");
 			return description;
 		}
 		return null;

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1201,107 +1201,127 @@
                                  referencedTableName="users" referencedColumnNames="user_id"/>
     </changeSet>
 
-    <changeSet id="openmrs.billing-006-20260508-create-bill-refund-table" author="Wikum Weerakutti">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <tableExists tableName="bill_refund"/>
-            </not>
-        </preConditions>
-        <comment>Create table for bill refunds with full audit trail</comment>
+	<changeSet id="openmrs.billing-006-20260508-create-bill-refund-table" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="bill_refund"/>
+			</not>
+		</preConditions>
+		<comment>Create table for bill refunds with full audit trail</comment>
 
-        <createTable tableName="bill_refund">
-            <column name="bill_refund_id" type="int" autoIncrement="true">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="bill_id" type="int">
-                <constraints nullable="false"/>
-            </column>
-            <column name="bill_line_item_id" type="int"/>
-            <column name="refund_amount" type="decimal(10,2)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="reason" type="varchar(1000)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="refund_status" type="varchar(20)" defaultValue="REQUESTED">
-                <constraints nullable="false"/>
-            </column>
-            <column name="initiator_id" type="int">
-                <constraints nullable="false"/>
-            </column>
-            <column name="approver_id" type="int"/>
-            <column name="completer_id" type="int"/>
-            <column name="date_approved" type="datetime"/>
-            <column name="date_completed" type="datetime"/>
-            <column name="creator" type="int">
-                <constraints nullable="false"/>
-            </column>
-            <column name="date_created" type="datetime">
-                <constraints nullable="false"/>
-            </column>
-            <column name="changed_by" type="int"/>
-            <column name="date_changed" type="datetime"/>
-            <column name="voided" type="boolean" defaultValueBoolean="false">
-                <constraints nullable="false"/>
-            </column>
-            <column name="voided_by" type="int"/>
-            <column name="date_voided" type="datetime"/>
-            <column name="void_reason" type="varchar(255)"/>
-            <column name="uuid" type="char(38)">
-                <constraints nullable="false" unique="true"/>
-            </column>
-        </createTable>
+		<createTable tableName="bill_refund">
+			<column name="bill_refund_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="bill_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="bill_line_item_id" type="int"/>
+			<column name="refund_amount" type="decimal(10,2)">
+				<constraints nullable="false"/>
+			</column>
+			<column name="reason" type="varchar(1000)">
+				<constraints nullable="false"/>
+			</column>
+			<column name="refund_status" type="varchar(20)" defaultValue="REQUESTED">
+				<constraints nullable="false"/>
+			</column>
+			<column name="initiator_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="approver_id" type="int"/>
+			<column name="completer_id" type="int"/>
+			<column name="date_approved" type="datetime"/>
+			<column name="date_completed" type="datetime"/>
+			<column name="creator" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="date_created" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="changed_by" type="int"/>
+			<column name="date_changed" type="datetime"/>
+			<column name="voided" type="boolean" defaultValueBoolean="false">
+				<constraints nullable="false"/>
+			</column>
+			<column name="voided_by" type="int"/>
+			<column name="date_voided" type="datetime"/>
+			<column name="void_reason" type="varchar(255)"/>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"/>
+			</column>
+		</createTable>
 
-        <addForeignKeyConstraint constraintName="bill_refund_bill_id_fk"
-                                 baseTableName="bill_refund" baseColumnNames="bill_id"
-                                 referencedTableName="cashier_bill" referencedColumnNames="bill_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_bill_id_fk"
+		                         baseTableName="bill_refund" baseColumnNames="bill_id"
+		                         referencedTableName="cashier_bill" referencedColumnNames="bill_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_bill_line_item_id_fk"
-                                 baseTableName="bill_refund" baseColumnNames="bill_line_item_id"
-                                 referencedTableName="cashier_bill_line_item" referencedColumnNames="bill_line_item_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_bill_line_item_id_fk"
+		                         baseTableName="bill_refund" baseColumnNames="bill_line_item_id"
+		                         referencedTableName="cashier_bill_line_item" referencedColumnNames="bill_line_item_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_initiator_id_fk"
-                                 baseTableName="bill_refund" baseColumnNames="initiator_id"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_initiator_id_fk"
+		                         baseTableName="bill_refund" baseColumnNames="initiator_id"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_approver_id_fk"
-                                 baseTableName="bill_refund" baseColumnNames="approver_id"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_approver_id_fk"
+		                         baseTableName="bill_refund" baseColumnNames="approver_id"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_completer_id_fk"
-                                 baseTableName="bill_refund" baseColumnNames="completer_id"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_completer_id_fk"
+		                         baseTableName="bill_refund" baseColumnNames="completer_id"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_creator_fk"
-                                 baseTableName="bill_refund" baseColumnNames="creator"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_creator_fk"
+		                         baseTableName="bill_refund" baseColumnNames="creator"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_changed_by_fk"
-                                 baseTableName="bill_refund" baseColumnNames="changed_by"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_changed_by_fk"
+		                         baseTableName="bill_refund" baseColumnNames="changed_by"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <addForeignKeyConstraint constraintName="bill_refund_voided_by_fk"
-                                 baseTableName="bill_refund" baseColumnNames="voided_by"
-                                 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="bill_refund_voided_by_fk"
+		                         baseTableName="bill_refund" baseColumnNames="voided_by"
+		                         referencedTableName="users" referencedColumnNames="user_id"/>
 
-        <createIndex tableName="bill_refund" indexName="idx_bill_refund_bill_id">
-            <column name="bill_id"/>
-        </createIndex>
+		<createIndex tableName="bill_refund" indexName="idx_bill_refund_bill_id">
+			<column name="bill_id"/>
+		</createIndex>
 
-        <createIndex tableName="bill_refund" indexName="idx_bill_refund_line_item_id">
-            <column name="bill_line_item_id"/>
-        </createIndex>
-    </changeSet>
+		<createIndex tableName="bill_refund" indexName="idx_bill_refund_line_item_id">
+			<column name="bill_line_item_id"/>
+		</createIndex>
+	</changeSet>
 
-    <changeSet id="openmrs.billing-007-20260508-widen-cashier-bill-status" author="Wikum Weerakutti">
-        <preConditions onFail="MARK_RAN">
-            <columnExists tableName="cashier_bill" columnName="status"/>
-        </preConditions>
-        <comment>Widen cashier_bill.status to fit refund-derived enum values (PARTIALLY_REFUNDED is 18 chars)</comment>
-        <modifyColumn tableName="cashier_bill">
-            <column name="status" type="varchar(20)">
-                <constraints nullable="false"/>
-            </column>
-        </modifyColumn>
-    </changeSet>
+	<changeSet id="openmrs.billing-007-20260508-widen-cashier-bill-status" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cashier_bill" columnName="status"/>
+		</preConditions>
+		<comment>Widen cashier_bill.status to fit refund-derived enum values (PARTIALLY_REFUNDED is 18 chars)</comment>
+		<modifyColumn tableName="cashier_bill">
+			<column name="status" type="varchar(20)">
+				<constraints nullable="false"/>
+			</column>
+		</modifyColumn>
+	</changeSet>
+
+	<changeSet id="openmrs.billing-005-20260512-fix-posted-line-item-status" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="0" >
+				SELECT 1 FROM cashier_bill_line_item WHERE payment_status = 'POSTED' LIMIT 1
+			</sqlCheck>
+		</preConditions>
+		<comment>POSTED is no longer a valid BillLineItemStatus; migrate any legacy rows to PENDING.</comment>
+		<update tableName="cashier_bill_line_item">
+			<column name="payment_status" value="PENDING"/>
+			<where>payment_status = 'POSTED'</where>
+		</update>
+	</changeSet>
+
+	<changeSet id="openmrs.billing-005-20260512-rename-payment-status" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cashier_bill_line_item" columnName="status"/>
+		</preConditions>
+		<renameColumn tableName="cashier_bill_line_item" oldColumnName="payment_status" newColumnName="status" columnDataType="varchar(20)" />
+	</changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1306,6 +1306,9 @@
 	</changeSet>
 
 	<changeSet id="openmrs.billing-008-20260512-fix-posted-line-item-status" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cashier_bill_line_item" columnName="payment_status"/>
+		</preConditions>
 		<comment>POSTED is no longer a valid BillLineItemStatus; migrate any legacy rows to PENDING.</comment>
 		<update tableName="cashier_bill_line_item">
 			<column name="payment_status" value="PENDING"/>
@@ -1318,5 +1321,17 @@
 			<columnExists tableName="cashier_bill_line_item" columnName="payment_status"/>
 		</preConditions>
 		<renameColumn tableName="cashier_bill_line_item" oldColumnName="payment_status" newColumnName="status" columnDataType="varchar(20)" />
+	</changeSet>
+
+	<changeSet id="openmrs.billing-010-20260512-enforce-line-item-status-not-null" author="Wikum Weerakutti">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cashier_bill_line_item" columnName="status"/>
+		</preConditions>
+		<comment>Backfill any unexpected NULL status rows as PENDING, then re-apply NOT NULL on the renamed column for cross-DB portability.</comment>
+		<update tableName="cashier_bill_line_item">
+			<column name="status" value="PENDING"/>
+			<where>status IS NULL</where>
+		</update>
+		<addNotNullConstraint tableName="cashier_bill_line_item" columnName="status" columnDataType="varchar(20)"/>
 	</changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1305,12 +1305,7 @@
 		</modifyColumn>
 	</changeSet>
 
-	<changeSet id="openmrs.billing-005-20260512-fix-posted-line-item-status" author="Wikum Weerakutti">
-		<preConditions onFail="MARK_RAN">
-			<sqlCheck expectedResult="0" >
-				SELECT 1 FROM cashier_bill_line_item WHERE payment_status = 'POSTED' LIMIT 1
-			</sqlCheck>
-		</preConditions>
+	<changeSet id="openmrs.billing-008-20260512-fix-posted-line-item-status" author="Wikum Weerakutti">
 		<comment>POSTED is no longer a valid BillLineItemStatus; migrate any legacy rows to PENDING.</comment>
 		<update tableName="cashier_bill_line_item">
 			<column name="payment_status" value="PENDING"/>
@@ -1318,9 +1313,9 @@
 		</update>
 	</changeSet>
 
-	<changeSet id="openmrs.billing-005-20260512-rename-payment-status" author="Wikum Weerakutti">
+	<changeSet id="openmrs.billing-009-20260512-rename-payment-status" author="Wikum Weerakutti">
 		<preConditions onFail="MARK_RAN">
-			<columnExists tableName="cashier_bill_line_item" columnName="status"/>
+			<columnExists tableName="cashier_bill_line_item" columnName="payment_status"/>
 		</preConditions>
 		<renameColumn tableName="cashier_bill_line_item" oldColumnName="payment_status" newColumnName="status" columnDataType="varchar(20)" />
 	</changeSet>


### PR DESCRIPTION
Introduce a dedicated `BillLineItemStatus` enum for `BillLineItem`, replacing the shared `BillStatus`. Drops the bill-only `POSTED` value and adds  `REFUND_REQUESTED`, `PARTIALLY_REFUNDED`, `REFUNDED` so line items reflect the state of line-scoped refunds.

- New `BillLineItemStatus` enum; `BillLineItem.paymentStatus` → `status` (field, column, REST JSON property).
- `BillRefundServiceImpl` reconciles line-item status on every line-scoped refund save, mirroring the existing bill-level rollup.
- `Bill.synchronizeBillStatus()` no longer overwrites a refund-state line item.
- Liquibase: migrate legacy `POSTED` line items → `PENDING`, widen + rename `payment_status` → `status`, widen `cashier_bill.status`.
- REST: `lineItem.paymentStatus` → `lineItem.status`. Frontend / ESM consumers must update.

Ticket: https://openmrs.atlassian.net/browse/O3-5422