### PR TITLE
 Enable refund and discount features by default

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -101,13 +101,13 @@
 	<globalProperty>
 		<property>${project.parent.artifactId}.discountEnabled</property>
 		<description>true/false whether or not the discount feature is enabled at the facility level.</description>
-		<defaultValue>false</defaultValue>
+		<defaultValue>true</defaultValue>
 	</globalProperty>
 
 	<globalProperty>
 		<property>${project.parent.artifactId}.refundEnabled</property>
 		<description>true/false whether or not the refund feature is enabled at the facility level.</description>
-		<defaultValue>false</defaultValue>
+		<defaultValue>true</defaultValue>
 	</globalProperty>
 
 	<globalProperty>


### PR DESCRIPTION
Flip the default values of the `billing.discountEnabled` and `billing.refundEnabled` global properties from `false` to `true` so the discount and refund workflows shipped in O3-5417 and O3-5413 are active out of the box.

