### PR TITLE
O3-5421: Associate bills with patient visits

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/billing/impl/AbstractDefaultOrderBillingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/billing/impl/AbstractDefaultOrderBillingStrategy.java
@@ -156,6 +156,9 @@ public abstract class AbstractDefaultOrderBillingStrategy extends AbstractOrderB
 		bill.setStatus(BillStatus.PENDING);
 		bill.setCashier(cashier);
 		bill.setCashPoint(cashPoint);
+		if (order.getEncounter() != null) {
+			bill.setVisit(order.getEncounter().getVisit());
+		}
 		bill.addLineItem(lineItem);
 		
 		Bill savedBill = billService.saveBill(bill);

--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
@@ -170,6 +170,10 @@ public class HibernateBillDAO implements BillDAO {
 			predicates.add(cb.equal(root.get("cashPoint").get("uuid"), billSearch.getCashPointUuid()));
 		}
 		
+		if (billSearch.getVisitUuid() != null) {
+			predicates.add(cb.equal(root.get("visit").get("uuid"), billSearch.getVisitUuid()));
+		}
+		
 		if (billSearch.getStatuses() != null && !billSearch.getStatuses().isEmpty()) {
 			predicates.add(root.get("status").in(billSearch.getStatuses()));
 		}

--- a/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmrs.BaseOpenmrsData;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
+import org.openmrs.Visit;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.util.PrivilegeConstants;
 import org.openmrs.module.stockmanagement.api.model.StockItem;
@@ -47,6 +48,8 @@ public class Bill extends BaseOpenmrsData {
 	private Patient patient;
 	
 	private CashPoint cashPoint;
+	
+	private Visit visit;
 	
 	private Bill billAdjusted;
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
@@ -37,6 +37,8 @@ public class BillSearch {
 	
 	private String cashPointUuid;
 	
+	private String visitUuid;
+	
 	private List<BillStatus> statuses;
 	
 	private List<DiscountStatus> discountStatuses;

--- a/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
+++ b/api/src/main/java/org/openmrs/module/billing/validator/BillValidator.java
@@ -11,12 +11,14 @@ package org.openmrs.module.billing.validator;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openmrs.Visit;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillLineItemService;
@@ -47,6 +49,7 @@ public class BillValidator implements Validator {
 			
 			validateNewPaymentsHaveCashier(bill, errors);
 			validateLineItemsNotModified(bill, errors);
+			validateVisitExistsAndBelongsToPatient(bill, errors);
 		}
 	}
 	
@@ -106,6 +109,27 @@ public class BillValidator implements Validator {
 				errors.reject("billing.error.paymentCashierRequired");
 				return;
 			}
+		}
+	}
+	
+	private void validateVisitExistsAndBelongsToPatient(Bill bill, Errors errors) {
+		if (bill.getVisit() == null) {
+			return;
+		}
+		
+		if (bill.getVisit().getVisitId() == null) {
+			errors.reject("billing.error.visitDoesNotExist");
+			return;
+		}
+		
+		Visit billVisit = Context.getVisitService().getVisit(bill.getVisit().getVisitId());
+		if (billVisit == null) {
+			errors.reject("billing.error.visitDoesNotExist");
+			return;
+		}
+		
+		if (!Objects.equals(billVisit.getPatient().getPatientId(), bill.getPatient().getPatientId())) {
+			errors.reject("billing.error.visitDoesNotBelongToPatient");
 		}
 	}
 	

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -116,6 +116,7 @@
 		<many-to-one name="patient" class="org.openmrs.Patient" not-null="true" column="patient_id"/>
 		<many-to-one name="cashPoint" class="org.openmrs.module.billing.api.model.CashPoint" not-null="true"
 		             column="cash_point_id"/>
+		<many-to-one name="visit" class="org.openmrs.Visit" column="visit_id" />
 		<many-to-one name="billAdjusted" class="org.openmrs.module.billing.api.model.Bill" column="adjusted_bill_id"/>
 
 		<property name="status" column="status" not-null="true">

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -116,7 +116,7 @@
 		<many-to-one name="patient" class="org.openmrs.Patient" not-null="true" column="patient_id"/>
 		<many-to-one name="cashPoint" class="org.openmrs.module.billing.api.model.CashPoint" not-null="true"
 		             column="cash_point_id"/>
-		<many-to-one name="visit" class="org.openmrs.Visit" column="visit_id" />
+		<many-to-one name="visit" class="org.openmrs.Visit" column="visit_id" index="cashier_bill_visit_id_idx"/>
 		<many-to-one name="billAdjusted" class="org.openmrs.module.billing.api.model.Bill" column="adjusted_bill_id"/>
 
 		<property name="status" column="status" not-null="true">

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -174,6 +174,8 @@ openhmis.cashier.paymentMode.attributeTypes.required=Attribute Types required
 openhmis.cashier.date=Date
 openhmis.cashier.general.confirm=Confirm
 openhmis.cashier.general.attributeTypeInUse.error=Attribute Type(s) in use and cannot be deleted
+billing.error.visitDoesNotExist=The visit attached to this bill does not exist.
+billing.error.visitDoesNotBelongToPatient=The visit attached does not belong to the patient being billed for
 #App
 openhmis.cashier.task.page=Cashier Tasks
 openhmis.cashier.manage.module=Manage Cashier Module

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -11,9 +11,13 @@ package org.openmrs.module.billing.api.billing.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -23,18 +27,28 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.Concept;
 import org.openmrs.DrugOrder;
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
 import org.openmrs.TestOrder;
+import org.openmrs.Visit;
 import org.openmrs.module.billing.api.BillExemptionService;
+import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.BillableServiceService;
+import org.openmrs.module.billing.api.CashPointService;
 import org.openmrs.module.billing.api.ItemPriceService;
+import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillLineItem;
 import org.openmrs.module.billing.api.model.BillLineItemStatus;
 import org.openmrs.module.billing.api.model.BillableService;
+import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.CashierItemPrice;
 import org.openmrs.module.billing.api.search.BillableServiceSearch;
 
@@ -49,6 +63,12 @@ public class TestOrderBillingStrategyTest {
 	
 	@Mock
 	private BillExemptionService billExemptionService;
+	
+	@Mock
+	private BillService billService;
+	
+	@Mock
+	private CashPointService cashPointService;
 	
 	@InjectMocks
 	private TestOrderBillingStrategy strategy;
@@ -130,5 +150,50 @@ public class TestOrderBillingStrategyTest {
 		Optional<BillLineItem> result = strategy.createBillLineItem(testOrder);
 		
 		assertFalse(result.isPresent());
+	}
+	
+	@Test
+	public void createBill_shouldInheritVisitFromOrderEncounter() {
+		Patient patient = mock(Patient.class);
+		Order order = mock(Order.class);
+		Encounter encounter = mock(Encounter.class);
+		Visit visit = mock(Visit.class);
+		Provider cashier = mock(Provider.class);
+		CashPoint cashPoint = mock(CashPoint.class);
+		BillLineItem lineItem = mock(BillLineItem.class);
+		
+		when(order.getEncounter()).thenReturn(encounter);
+		when(encounter.getVisit()).thenReturn(visit);
+		when(order.getOrderer()).thenReturn(cashier);
+		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
+		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));
+		
+		strategy.createBill(patient, lineItem, order);
+		
+		ArgumentCaptor<Bill> captor = ArgumentCaptor.forClass(Bill.class);
+		verify(billService).saveBill(captor.capture());
+		assertEquals(visit, captor.getValue().getVisit());
+	}
+	
+	@Test
+	public void createBill_shouldLeaveVisitNullWhenEncounterHasNoVisit() {
+		Patient patient = mock(Patient.class);
+		Order order = mock(Order.class);
+		Encounter encounter = mock(Encounter.class);
+		Provider cashier = mock(Provider.class);
+		CashPoint cashPoint = mock(CashPoint.class);
+		BillLineItem lineItem = mock(BillLineItem.class);
+		
+		lenient().when(order.getEncounter()).thenReturn(encounter);
+		lenient().when(encounter.getVisit()).thenReturn(null);
+		when(order.getOrderer()).thenReturn(cashier);
+		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
+		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));
+		
+		strategy.createBill(patient, lineItem, order);
+		
+		ArgumentCaptor<Bill> captor = ArgumentCaptor.forClass(Bill.class);
+		verify(billService).saveBill(captor.capture());
+		assertNull(captor.getValue().getVisit());
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -161,7 +161,7 @@ public class TestOrderBillingStrategyTest {
 		Order order = new TestOrder();
 		order.setEncounter(encounter);
 		order.setOrderer(cashier);
-		CashPoint cashPoint = mock(CashPoint.class);
+		CashPoint cashPoint = new CashPoint();
 		BillLineItem lineItem = mock(BillLineItem.class);
 		
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
@@ -182,7 +182,7 @@ public class TestOrderBillingStrategyTest {
 		Order order = new TestOrder();
 		order.setEncounter(encounter);
 		order.setOrderer(cashier);
-		CashPoint cashPoint = mock(CashPoint.class);
+		CashPoint cashPoint = new CashPoint();
 		BillLineItem lineItem = mock(BillLineItem.class);
 		
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -162,7 +161,7 @@ public class TestOrderBillingStrategyTest {
 		order.setEncounter(encounter);
 		order.setOrderer(cashier);
 		CashPoint cashPoint = new CashPoint();
-		BillLineItem lineItem = mock(BillLineItem.class);
+		BillLineItem lineItem = new BillLineItem();
 		
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
 		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));
@@ -183,7 +182,7 @@ public class TestOrderBillingStrategyTest {
 		order.setEncounter(encounter);
 		order.setOrderer(cashier);
 		CashPoint cashPoint = new CashPoint();
-		BillLineItem lineItem = mock(BillLineItem.class);
+		BillLineItem lineItem = new BillLineItem();
 		
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
 		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -155,16 +154,16 @@ public class TestOrderBillingStrategyTest {
 	@Test
 	public void createBill_shouldInheritVisitFromOrderEncounter() {
 		Patient patient = new Patient();
-		Order order = mock(Order.class);
-		Encounter encounter = mock(Encounter.class);
-		Visit visit = mock(Visit.class);
-		Provider cashier = mock(Provider.class);
+		Visit visit = new Visit();
+		Encounter encounter = new Encounter();
+		encounter.setVisit(visit);
+		Provider cashier = new Provider();
+		Order order = new TestOrder();
+		order.setEncounter(encounter);
+		order.setOrderer(cashier);
 		CashPoint cashPoint = mock(CashPoint.class);
 		BillLineItem lineItem = mock(BillLineItem.class);
 		
-		when(order.getEncounter()).thenReturn(encounter);
-		when(encounter.getVisit()).thenReturn(visit);
-		when(order.getOrderer()).thenReturn(cashier);
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
 		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));
 		
@@ -178,15 +177,14 @@ public class TestOrderBillingStrategyTest {
 	@Test
 	public void createBill_shouldLeaveVisitNullWhenEncounterHasNoVisit() {
 		Patient patient = new Patient();
-		Order order = mock(Order.class);
-		Encounter encounter = mock(Encounter.class);
-		Provider cashier = mock(Provider.class);
+		Encounter encounter = new Encounter();
+		Provider cashier = new Provider();
+		Order order = new TestOrder();
+		order.setEncounter(encounter);
+		order.setOrderer(cashier);
 		CashPoint cashPoint = mock(CashPoint.class);
 		BillLineItem lineItem = mock(BillLineItem.class);
 		
-		lenient().when(order.getEncounter()).thenReturn(encounter);
-		lenient().when(encounter.getVisit()).thenReturn(null);
-		when(order.getOrderer()).thenReturn(cashier);
 		when(cashPointService.getAllCashPoints(false)).thenReturn(Collections.singletonList(cashPoint));
 		when(billService.saveBill(any(Bill.class))).thenAnswer(inv -> inv.getArgument(0));
 		

--- a/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/billing/impl/TestOrderBillingStrategyTest.java
@@ -154,7 +154,7 @@ public class TestOrderBillingStrategyTest {
 	
 	@Test
 	public void createBill_shouldInheritVisitFromOrderEncounter() {
-		Patient patient = mock(Patient.class);
+		Patient patient = new Patient();
 		Order order = mock(Order.class);
 		Encounter encounter = mock(Encounter.class);
 		Visit visit = mock(Visit.class);
@@ -177,7 +177,7 @@ public class TestOrderBillingStrategyTest {
 	
 	@Test
 	public void createBill_shouldLeaveVisitNullWhenEncounterHasNoVisit() {
-		Patient patient = mock(Patient.class);
+		Patient patient = new Patient();
 		Order order = mock(Order.class);
 		Encounter encounter = mock(Encounter.class);
 		Provider cashier = mock(Provider.class);

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -460,7 +460,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		billA.setStatus(BillStatus.PENDING);
 		billA.setVisit(visitA);
 		BillLineItem lineItemA = billA.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
-		lineItemA.setPaymentStatus(BillStatus.PENDING);
+		lineItemA.setStatus(BillLineItemStatus.PENDING);
 		lineItemA.setUuid(UUID.randomUUID().toString());
 		billService.saveBill(billA);
 		
@@ -472,7 +472,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		billB.setStatus(BillStatus.PENDING);
 		billB.setVisit(visitB);
 		BillLineItem lineItemB = billB.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
-		lineItemB.setPaymentStatus(BillStatus.PENDING);
+		lineItemB.setStatus(BillLineItemStatus.PENDING);
 		lineItemB.setUuid(UUID.randomUUID().toString());
 		billService.saveBill(billB);
 		
@@ -619,7 +619,7 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		newBill.setVisit(savedVisit);
 		
 		BillLineItem lineItem = newBill.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
-		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setStatus(BillLineItemStatus.PENDING);
 		lineItem.setUuid(UUID.randomUUID().toString());
 		
 		Bill saved = billService.saveBill(newBill);

--- a/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/impl/BillServiceImplTest.java
@@ -16,10 +16,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UnchangeableObjectException;
 import org.openmrs.api.ValidationException;
+import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
@@ -420,6 +423,73 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#getBills(BillSearch, PagingInfo)
 	 */
 	@Test
+	public void getBills_shouldFilterByVisitUuid() {
+		VisitService visitService = Context.getVisitService();
+		Patient patient = patientService.getPatient(1);
+		
+		org.openmrs.VisitType visitType;
+		if (visitService.getAllVisitTypes().isEmpty()) {
+			visitType = visitService.saveVisitType(new org.openmrs.VisitType("Test", "Test visit type"));
+		} else {
+			visitType = visitService.getAllVisitTypes().get(0);
+		}
+		
+		Visit visitA = new Visit();
+		visitA.setPatient(patient);
+		visitA.setVisitType(visitType);
+		visitA.setStartDatetime(new java.util.Date());
+		visitA = visitService.saveVisit(visitA);
+		
+		Visit visitB = new Visit();
+		visitB.setPatient(patient);
+		visitB.setVisitType(visitType);
+		visitB.setStartDatetime(new java.util.Date());
+		visitB = visitService.saveVisit(visitB);
+		
+		Bill templateBill = billService.getBill(0);
+		assertNotNull(templateBill);
+		assertFalse(templateBill.getLineItems().isEmpty());
+		BillLineItem existingItem = templateBill.getLineItems().get(0);
+		StockItem stockItem = existingItem.getItem();
+		
+		Bill billA = new Bill();
+		billA.setCashier(providerService.getProvider(0));
+		billA.setPatient(patient);
+		billA.setCashPoint(cashPointService.getCashPoint(0));
+		billA.setReceiptNumber("TEST-VISIT-A-" + UUID.randomUUID());
+		billA.setStatus(BillStatus.PENDING);
+		billA.setVisit(visitA);
+		BillLineItem lineItemA = billA.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
+		lineItemA.setPaymentStatus(BillStatus.PENDING);
+		lineItemA.setUuid(UUID.randomUUID().toString());
+		billService.saveBill(billA);
+		
+		Bill billB = new Bill();
+		billB.setCashier(providerService.getProvider(0));
+		billB.setPatient(patient);
+		billB.setCashPoint(cashPointService.getCashPoint(0));
+		billB.setReceiptNumber("TEST-VISIT-B-" + UUID.randomUUID());
+		billB.setStatus(BillStatus.PENDING);
+		billB.setVisit(visitB);
+		BillLineItem lineItemB = billB.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
+		lineItemB.setPaymentStatus(BillStatus.PENDING);
+		lineItemB.setUuid(UUID.randomUUID().toString());
+		billService.saveBill(billB);
+		
+		Context.flushSession();
+		
+		BillSearch search = new BillSearch();
+		search.setVisitUuid(visitA.getUuid());
+		java.util.List<Bill> results = billService.getBills(search, new PagingInfo());
+		
+		assertEquals(1, results.size());
+		assertEquals(visitA.getUuid(), results.get(0).getVisit().getUuid());
+	}
+	
+	/**
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#getBills(BillSearch, PagingInfo)
+	 */
+	@Test
 	public void getBills_shouldReturnAllBillsWhenSearchIsEmpty() {
 		BillSearch billSearch = new BillSearch();
 		List<Bill> bills = billService.getBills(billSearch, null);
@@ -504,5 +574,64 @@ public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
 		assertNotNull(savedBill);
 		assertNotNull(savedBill.getReceiptNumber());
 		assertFalse(savedBill.getReceiptNumber().isEmpty());
+	}
+	
+	/**
+	 * @see org.openmrs.module.billing.api.impl.BillServiceImpl#saveBill(Bill)
+	 */
+	@Test
+	public void saveBill_shouldPersistVisitAssociation() {
+		Patient patient = patientService.getPatient(1);
+		assertNotNull(patient);
+		
+		// Obtain a VisitType from the test dataset; create one if none exist
+		VisitService visitService = Context.getVisitService();
+		List<VisitType> visitTypes = visitService.getAllVisitTypes();
+		VisitType visitType;
+		if (visitTypes.isEmpty()) {
+			visitType = visitService.saveVisitType(new VisitType("Test", "Test visit type"));
+		} else {
+			visitType = visitTypes.get(0);
+		}
+		
+		Visit visit = new Visit();
+		visit.setPatient(patient);
+		visit.setVisitType(visitType);
+		visit.setStartDatetime(new java.util.Date());
+		Visit savedVisit = visitService.saveVisit(visit);
+		assertNotNull(savedVisit);
+		assertNotNull(savedVisit.getUuid());
+		
+		// Build a bill the same way saveBill_shouldCreateNewBillWithNewItem does
+		Bill templateBill = billService.getBill(0);
+		assertNotNull(templateBill);
+		assertFalse(templateBill.getLineItems().isEmpty());
+		
+		BillLineItem existingItem = templateBill.getLineItems().get(0);
+		StockItem stockItem = existingItem.getItem();
+		
+		Bill newBill = new Bill();
+		newBill.setCashier(providerService.getProvider(0));
+		newBill.setPatient(patient);
+		newBill.setCashPoint(cashPointService.getCashPoint(0));
+		newBill.setReceiptNumber("TEST-VISIT-" + UUID.randomUUID());
+		newBill.setStatus(BillStatus.PENDING);
+		newBill.setVisit(savedVisit);
+		
+		BillLineItem lineItem = newBill.addLineItem(stockItem, BigDecimal.valueOf(100), "Test price", 1);
+		lineItem.setPaymentStatus(BillStatus.PENDING);
+		lineItem.setUuid(UUID.randomUUID().toString());
+		
+		Bill saved = billService.saveBill(newBill);
+		assertNotNull(saved);
+		assertNotNull(saved.getId());
+		
+		Context.flushSession();
+		Context.clearSession();
+		
+		Bill reloaded = billService.getBill(saved.getId());
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.getVisit());
+		assertEquals(savedVisit.getUuid(), reloaded.getVisit().getUuid());
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/validator/BillValidatorTest.java
@@ -12,10 +12,15 @@ package org.openmrs.module.billing.validator;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
+import java.util.Date;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.VisitService;
 import org.openmrs.module.billing.TestConstants;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.PaymentModeService;
@@ -134,6 +139,50 @@ public class BillValidatorTest extends BaseModuleContextSensitiveTest {
 		billValidator.validate(postedBill, errors);
 		
 		assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldRejectVisitThatDoesNotExist() {
+		Bill pendingBill = billService.getBill(2);
+		assertNotNull(pendingBill);
+		
+		Visit missingVisit = new Visit();
+		missingVisit.setVisitId(Integer.MAX_VALUE);
+		pendingBill.setVisit(missingVisit);
+		
+		Errors errors = new BindException(pendingBill, "bill");
+		billValidator.validate(pendingBill, errors);
+		
+		assertTrue(errors.hasGlobalErrors());
+		assertEquals("billing.error.visitDoesNotExist", errors.getGlobalError().getCode());
+	}
+	
+	@Test
+	public void validate_shouldRejectVisitThatDoesNotBelongToPatient() {
+		Bill pendingBill = billService.getBill(2);
+		assertNotNull(pendingBill);
+		assertNotEquals(0, pendingBill.getPatient().getPatientId());
+		
+		VisitService visitService = Context.getVisitService();
+		VisitType visitType = visitService.getAllVisitTypes().isEmpty()
+		        ? visitService.saveVisitType(new VisitType("Test", "Test visit type"))
+		        : visitService.getAllVisitTypes().get(0);
+		Patient otherPatient = Context.getPatientService().getPatient(0);
+		otherPatient.setBirthdateEstimated(false);
+		
+		Visit otherPatientVisit = new Visit();
+		otherPatientVisit.setPatient(otherPatient);
+		otherPatientVisit.setVisitType(visitType);
+		otherPatientVisit.setStartDatetime(new Date());
+		otherPatientVisit = visitService.saveVisit(otherPatientVisit);
+		
+		pendingBill.setVisit(otherPatientVisit);
+		
+		Errors errors = new BindException(pendingBill, "bill");
+		billValidator.validate(pendingBill, errors);
+		
+		assertTrue(errors.hasGlobalErrors());
+		assertEquals("billing.error.visitDoesNotBelongToPatient", errors.getGlobalError().getCode());
 	}
 	
 }

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -17,8 +17,10 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Provider;
+import org.openmrs.Visit;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.base.ProviderUtil;
@@ -57,6 +59,7 @@ import org.springframework.web.client.RestClientException;
 /**
  * REST resource representing a {@link Bill}.
  */
+@Slf4j
 @Resource(name = RestConstants.VERSION_1 + CashierResourceController.BILLING_NAMESPACE
         + "/bill", supportedClass = Bill.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
 public class BillResource extends DataDelegatingCrudResource<Bill> {
@@ -68,6 +71,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			description.addProperty("adjustedBy", Representation.REF);
 			description.addProperty("billAdjusted", Representation.REF);
 			description.addProperty("cashPoint", Representation.REF);
+			description.addProperty("visit", Representation.REF);
 			description.addProperty("cashier", Representation.REF);
 			description.addProperty("dateCreated");
 			description.addProperty("lineItems");
@@ -94,6 +98,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		description.addProperty("adjustedBy");
 		description.addProperty("billAdjusted");
 		description.addProperty("cashPoint");
+		description.addProperty("visit");
 		description.addProperty("cashier");
 		description.addProperty("lineItems");
 		description.addProperty("patient");
@@ -188,6 +193,16 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			
 			if (bill.getCashPoint() == null) {
 				loadBillCashPoint(bill);
+			}
+			
+			if (bill.getVisit() == null && bill.getPatient() != null) {
+				List<Visit> active = Context.getVisitService().getActiveVisitsByPatient(bill.getPatient());
+				if (active != null && active.size() == 1) {
+					bill.setVisit(active.get(0));
+				} else if (active != null && active.size() > 1) {
+					log.info("Bill for patient {} has {} active visits; leaving visit unset", bill.getPatient().getUuid(),
+					    active.size());
+				}
 			}
 			
 			// Now that all attributes have been set (i.e., payments and bill status) we can check to see if the bill
@@ -300,6 +315,11 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		String cashPointUuid = context.getRequest().getParameter("cashPointUuid");
 		if (StringUtils.isNotBlank(cashPointUuid)) {
 			billSearch.setCashPointUuid(cashPointUuid);
+		}
+		
+		String visitUuid = context.getRequest().getParameter("visitUuid");
+		if (StringUtils.isNotBlank(visitUuid)) {
+			billSearch.setVisitUuid(visitUuid);
 		}
 		
 		String discountStatus = context.getRequest().getParameter("discountStatus");

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -182,13 +182,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		
 		if (bill.getId() == null) {
 			if (bill.getCashier() == null) {
-				Provider cashier = getCurrentCashier();
-				if (cashier == null) {
-					throw new RestClientException(
-					        "The current user (" + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
-				}
-				
-				bill.setCashier(cashier);
+				assignCurrentCashier(bill);
 			}
 			
 			if (bill.getCashPoint() == null) {
@@ -196,21 +190,10 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			}
 			
 			if (bill.getVisit() == null && bill.getPatient() != null) {
-				List<Visit> active = Context.getVisitService().getActiveVisitsByPatient(bill.getPatient());
-				if (active != null && active.size() == 1) {
-					bill.setVisit(active.get(0));
-				} else if (active != null && active.size() > 1) {
-					log.info("Bill for patient {} has {} active visits; leaving visit unset", bill.getPatient().getUuid(),
-					    active.size());
-				}
+				assignActiveVisit(bill);
 			}
 			
-			// Now that all attributes have been set (i.e., payments and bill status) we can check to see if the bill
-			// is fully paid.
-			bill.synchronizeBillStatus();
-			if (bill.getStatus() == null) {
-				bill.setStatus(BillStatus.PENDING);
-			}
+			initializeBillStatus(bill);
 		}
 		
 		return Context.getService(BillService.class).saveBill(bill);
@@ -259,6 +242,40 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 	
 	private Provider getCurrentCashier() {
 		return ProviderUtil.getCurrentProvider();
+	}
+	
+	private void assignCurrentCashier(Bill bill) {
+		Provider cashier = getCurrentCashier();
+		if (cashier == null) {
+			throw new RestClientException(
+			        "The current user (" + Context.getAuthenticatedUser().getUsername() + ") is not a provider");
+		}
+		
+		bill.setCashier(cashier);
+	}
+	
+	private void assignActiveVisit(Bill bill) {
+		List<Visit> activeVisits = Context.getVisitService().getActiveVisitsByPatient(bill.getPatient());
+		if (activeVisits == null || activeVisits.isEmpty()) {
+			return;
+		}
+		
+		if (activeVisits.size() == 1) {
+			bill.setVisit(activeVisits.get(0));
+			return;
+		}
+		
+		log.info("Bill for patient {} has {} active visits; leaving visit unset", bill.getPatient().getUuid(),
+		    activeVisits.size());
+	}
+	
+	private void initializeBillStatus(Bill bill) {
+		// Now that all attributes have been set (i.e., payments and bill status) we can check to see if the bill
+		// is fully paid.
+		bill.synchronizeBillStatus();
+		if (bill.getStatus() == null) {
+			bill.setStatus(BillStatus.PENDING);
+		}
 	}
 	
 	private void loadBillCashPoint(Bill bill) {

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1334,4 +1334,26 @@
 		</update>
 		<addNotNullConstraint tableName="cashier_bill_line_item" columnName="status" columnDataType="varchar(20)"/>
 	</changeSet>
+
+    <changeSet id="openmrs.billing-011-20260515-add-visit-to-bill" author="Nethmi Rodrigo">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="cashier_bill" columnName="visit_id" />
+            </not>
+        </preConditions>
+        <comment>Add nullable visit_id column and FK to cashier_bill</comment>
+        <addColumn tableName="cashier_bill">
+            <column name="visit_id" type="int">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint
+            constraintName="cashier_bill_visit_fk"
+            baseTableName="cashier_bill"
+            baseColumnNames="visit_id"
+            referencedTableName="visit"
+            referencedColumnNames="visit_id"
+            onDelete="SET NULL"
+            onUpdate="CASCADE" />
+    </changeSet>
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1356,4 +1356,16 @@
             onDelete="SET NULL"
             onUpdate="CASCADE" />
     </changeSet>
+
+    <changeSet id="openmrs.billing-012-20260519-index-bill-visit" author="Nethmi Rodrigo">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="cashier_bill" indexName="cashier_bill_visit_id_idx" />
+            </not>
+        </preConditions>
+        <comment>Add index for cashier_bill.visit_id</comment>
+        <createIndex indexName="cashier_bill_visit_id_idx" tableName="cashier_bill">
+            <column name="visit_id" />
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
@@ -17,10 +17,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -29,9 +33,16 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
+import org.openmrs.Visit;
+import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.base.PagingInfo;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.DiscountStatus;
 import org.openmrs.module.billing.api.search.BillSearch;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -126,5 +137,121 @@ public class BillResourceTest {
 		resource.doSearch(context);
 		
 		assertNull(capturedSearches.get(0).getDiscountStatuses());
+	}
+	
+	@Test
+	public void doSearch_shouldPassVisitUuidIntoBillSearch() {
+		RequestContext context = mock(RequestContext.class);
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(context.getRequest()).thenReturn(request);
+		when(request.getParameter("visitUuid")).thenReturn("11111111-1111-1111-1111-111111111111");
+		when(context.getLimit()).thenReturn(10);
+		when(context.getStartIndex()).thenReturn(0);
+		
+		resource.doSearch(context);
+		
+		assertEquals(1, capturedSearches.size());
+		assertEquals("11111111-1111-1111-1111-111111111111", capturedSearches.get(0).getVisitUuid());
+	}
+	
+	@Test
+	public void doSearch_shouldLeaveVisitUuidNullWhenAbsent() {
+		RequestContext context = mock(RequestContext.class);
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(context.getRequest()).thenReturn(request);
+		when(request.getParameter("visitUuid")).thenReturn(null);
+		when(context.getLimit()).thenReturn(10);
+		when(context.getStartIndex()).thenReturn(0);
+		
+		resource.doSearch(context);
+		
+		assertNull(capturedSearches.get(0).getVisitUuid());
+	}
+	
+	@Test
+	public void save_shouldAutoPopulateVisitWhenPatientHasSingleActiveVisit() {
+		VisitService visitService = mock(VisitService.class);
+		contextMock.when(() -> Context.getVisitService()).thenReturn(visitService);
+		
+		Patient patient = new Patient();
+		Visit visit = new Visit();
+		when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Collections.singletonList(visit));
+		when(billService.saveBill(any())).thenAnswer(inv -> inv.getArgument(0));
+		
+		Bill bill = new Bill();
+		bill.setPatient(patient);
+		bill.setCashier(new Provider());
+		bill.setCashPoint(new CashPoint());
+		bill.setStatus(BillStatus.PENDING);
+		bill.setPayments(new HashSet<>());
+		
+		resource.save(bill);
+		
+		assertEquals(visit, bill.getVisit());
+	}
+	
+	@Test
+	public void save_shouldLeaveVisitNullWhenZeroActiveVisits() {
+		VisitService visitService = mock(VisitService.class);
+		contextMock.when(() -> Context.getVisitService()).thenReturn(visitService);
+		
+		Patient patient = new Patient();
+		when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Collections.emptyList());
+		when(billService.saveBill(any())).thenAnswer(inv -> inv.getArgument(0));
+		
+		Bill bill = new Bill();
+		bill.setPatient(patient);
+		bill.setCashier(new Provider());
+		bill.setCashPoint(new CashPoint());
+		bill.setStatus(BillStatus.PENDING);
+		bill.setPayments(new HashSet<>());
+		
+		resource.save(bill);
+		
+		assertNull(bill.getVisit());
+	}
+	
+	@Test
+	public void save_shouldLeaveVisitNullWhenMultipleActiveVisits() {
+		VisitService visitService = mock(VisitService.class);
+		contextMock.when(() -> Context.getVisitService()).thenReturn(visitService);
+		
+		Patient patient = new Patient();
+		when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(new Visit(), new Visit()));
+		when(billService.saveBill(any())).thenAnswer(inv -> inv.getArgument(0));
+		
+		Bill bill = new Bill();
+		bill.setPatient(patient);
+		bill.setCashier(new Provider());
+		bill.setCashPoint(new CashPoint());
+		bill.setStatus(BillStatus.PENDING);
+		bill.setPayments(new HashSet<>());
+		
+		resource.save(bill);
+		
+		assertNull(bill.getVisit());
+	}
+	
+	@Test
+	public void save_shouldKeepCallerSuppliedVisit() {
+		VisitService visitService = mock(VisitService.class);
+		contextMock.when(() -> Context.getVisitService()).thenReturn(visitService);
+		
+		Patient patient = new Patient();
+		Visit caller = new Visit();
+		when(billService.saveBill(any())).thenAnswer(inv -> inv.getArgument(0));
+		
+		Bill bill = new Bill();
+		bill.setPatient(patient);
+		bill.setVisit(caller);
+		bill.setCashier(new Provider());
+		bill.setCashPoint(new CashPoint());
+		bill.setStatus(BillStatus.PENDING);
+		bill.setPayments(new HashSet<>());
+		
+		resource.save(bill);
+		
+		assertEquals(caller, bill.getVisit());
+		verify(visitService, never()).getActiveVisitsByPatient(any());
 	}
 }


### PR DESCRIPTION
## Summary

Adds an optional `visit` association to `Bill` so bills can be linked to the visit they were generated during. The visit can be supplied explicitly via the REST API, is auto-populated from a patient's single active visit on create, and is auto-set from an order's encounter when a bill is generated from orders. Bills can also be filtered by `visitUuid`.

## Changes

- Schema: add `visit_id` column to `cashier_bill` with `ON DELETE SET NULL` / `ON UPDATE CASCADE`
- Entity: `Bill.visit` field with Hibernate mapping
- REST: expose `visit` on `BillResource` (DEFAULT/FULL reps + creatable property); accept `visitUuid` query param on bill search
- Search: `BillSearch.visitUuid` filter wired through criteria
- Auto-population: when creating a bill without a visit, use the patient's single active visit (skip if multiple)
- Order-driven: when generating a bill from orders, set the visit from the order's encounter
