### PR TITLE
O3-5410: Display Billing Payment Status Without Blocking Access to Clinical Forms

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
+++ b/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
@@ -61,6 +61,8 @@ public class ModuleSettings {
 	
 	public static final String PAYMENTS_BY_PAYMENT_MODE_REPORT_ID_PROPERTY = "billing.reports.paymentsByPaymentMode";
 	
+	public static final String PATIENT_PAYMENT_STATUS_RESOLVER = "billing.patientPaymentStatusResolver";
+	
 	private static final AdministrationService administrationService;
 	
 	static {

--- a/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolver.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolver.java
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api;
+
+import org.openmrs.Patient;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+
+public interface PatientPaymentStatusResolver {
+	
+	PatientPaymentStatusResult resolve(Patient patient);
+}

--- a/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactory.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactory.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.ModuleSettings;
+import org.openmrs.util.OpenmrsClassLoader;
+
+import java.lang.reflect.InvocationTargetException;
+
+@RequiredArgsConstructor
+public class PatientPaymentStatusResolverFactory {
+	
+	private final PatientPaymentStatusResolver defaultPatientPaymentStatusResolver;
+	
+	private volatile String cachedResolverClassName;
+	
+	private volatile PatientPaymentStatusResolver cachedResolver;
+	
+	public PatientPaymentStatusResolver getResolver() {
+		String resolverClassName = Context.getAdministrationService()
+		        .getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER);
+		if (StringUtils.isBlank(resolverClassName)) {
+			return defaultPatientPaymentStatusResolver;
+		}
+		synchronized (this) {
+			if (!StringUtils.equals(resolverClassName, cachedResolverClassName)) {
+				cachedResolver = instantiate(resolverClassName);
+				cachedResolverClassName = resolverClassName;
+			}
+			return cachedResolver;
+		}
+	}
+	
+	private PatientPaymentStatusResolver instantiate(String resolverClassName) {
+		try {
+			Class<?> cls = OpenmrsClassLoader.getInstance().loadClass(resolverClassName);
+			if (!PatientPaymentStatusResolver.class.isAssignableFrom(cls)) {
+				throw new APIException("Class '" + resolverClassName + "' does not implement PatientPaymentStatusResolver");
+			}
+			return (PatientPaymentStatusResolver) cls.getDeclaredConstructor().newInstance();
+		}
+		catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | InstantiationException
+		        | NoSuchMethodException e) {
+			throw new APIException("Failed to load patient payment status resolver '" + resolverClassName + "'", e);
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactory.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactory.java
@@ -9,50 +9,22 @@
  */
 package org.openmrs.module.billing.api;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.ModuleSettings;
-import org.openmrs.util.OpenmrsClassLoader;
+import org.openmrs.module.billing.api.impl.DefaultPatientPaymentStatusResolver;
 
-import java.lang.reflect.InvocationTargetException;
-
-@RequiredArgsConstructor
 public class PatientPaymentStatusResolverFactory {
 	
-	private final PatientPaymentStatusResolver defaultPatientPaymentStatusResolver;
-	
-	private volatile String cachedResolverClassName;
-	
-	private volatile PatientPaymentStatusResolver cachedResolver;
-	
 	public PatientPaymentStatusResolver getResolver() {
-		String resolverClassName = Context.getAdministrationService()
+		String configured = Context.getAdministrationService()
 		        .getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER);
-		if (StringUtils.isBlank(resolverClassName)) {
-			return defaultPatientPaymentStatusResolver;
-		}
-		synchronized (this) {
-			if (!StringUtils.equals(resolverClassName, cachedResolverClassName)) {
-				cachedResolver = instantiate(resolverClassName);
-				cachedResolverClassName = resolverClassName;
-			}
-			return cachedResolver;
-		}
-	}
-	
-	private PatientPaymentStatusResolver instantiate(String resolverClassName) {
-		try {
-			Class<?> cls = OpenmrsClassLoader.getInstance().loadClass(resolverClassName);
-			if (!PatientPaymentStatusResolver.class.isAssignableFrom(cls)) {
-				throw new APIException("Class '" + resolverClassName + "' does not implement PatientPaymentStatusResolver");
-			}
-			return (PatientPaymentStatusResolver) cls.getDeclaredConstructor().newInstance();
-		}
-		catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | InstantiationException
-		        | NoSuchMethodException e) {
-			throw new APIException("Failed to load patient payment status resolver '" + resolverClassName + "'", e);
-		}
+		String target = StringUtils.isBlank(configured) ? DefaultPatientPaymentStatusResolver.class.getName() : configured;
+		
+		return Context.getRegisteredComponents(PatientPaymentStatusResolver.class).stream()
+		        .filter(resolver -> target.equals(resolver.getClass().getName())).findFirst()
+		        .orElseThrow(() -> new APIException("No registered PatientPaymentStatusResolver bean matches class '"
+		                + target + "'. Ensure the resolver is a Spring component scanned by an OpenMRS module."));
 	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.openmrs.Patient;
+import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.PatientPaymentStatusResolver;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.PatientPaymentStatus;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DefaultPatientPaymentStatusResolver implements PatientPaymentStatusResolver {
+	
+	private final BillService billService;
+	
+	@Override
+	public PatientPaymentStatusResult resolve(Patient patient) {
+		List<Bill> bills = billService.getBillsByPatientUuid(patient.getUuid(), null);
+		boolean hasOutstanding = bills.stream().filter(b -> !Boolean.TRUE.equals(b.getVoided()))
+		        .anyMatch(b -> b.getStatus() == BillStatus.PENDING || b.getStatus() == BillStatus.POSTED);
+		
+		return PatientPaymentStatusResult.builder()
+		        .status(hasOutstanding ? PatientPaymentStatus.UNPAID : PatientPaymentStatus.PAID)
+		        .reason(hasOutstanding ? "Outstanding bill(s) present" : "No outstanding bills").build();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
@@ -11,6 +11,7 @@ package org.openmrs.module.billing.api.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.PatientPaymentStatusResolver;
 import org.openmrs.module.billing.api.model.Bill;
@@ -23,6 +24,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DefaultPatientPaymentStatusResolver implements PatientPaymentStatusResolver {
 	
+	static final String MSG_OUTSTANDING = "billing.patientPaymentStatus.outstanding";
+	
+	static final String MSG_NO_OUTSTANDING = "billing.patientPaymentStatus.noOutstanding";
+	
 	private final BillService billService;
 	
 	@Override
@@ -31,8 +36,8 @@ public class DefaultPatientPaymentStatusResolver implements PatientPaymentStatus
 		boolean hasOutstanding = bills.stream().filter(b -> !Boolean.TRUE.equals(b.getVoided()))
 		        .anyMatch(b -> b.getStatus() == BillStatus.PENDING || b.getStatus() == BillStatus.POSTED);
 		
+		String reason = Context.getMessageSourceService().getMessage(hasOutstanding ? MSG_OUTSTANDING : MSG_NO_OUTSTANDING);
 		return PatientPaymentStatusResult.builder()
-		        .status(hasOutstanding ? PatientPaymentStatus.UNPAID : PatientPaymentStatus.PAID)
-		        .reason(hasOutstanding ? "Outstanding bill(s) present" : "No outstanding bills").build();
+		        .status(hasOutstanding ? PatientPaymentStatus.UNPAID : PatientPaymentStatus.PAID).reason(reason).build();
 	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/model/PatientPaymentStatus.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/PatientPaymentStatus.java
@@ -1,0 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.model;
+
+public enum PatientPaymentStatus {
+	PAID,
+	UNPAID,
+	UNKNOWN
+}

--- a/api/src/main/java/org/openmrs/module/billing/api/model/PatientPaymentStatusResult.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/PatientPaymentStatusResult.java
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PatientPaymentStatusResult {
+	
+	private PatientPaymentStatus status;
+	
+	private String reason;
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -254,3 +254,7 @@ openhmis.cashier.report.generate.excel=As Excel
 openhmis.cashier.report.generate.pdf=As PDF
 openhmis.cashier.report.error.beginAndEndDate=You must select a begin and end date to generate the report.
 openhmis.cashier.report.error.selectReport=You must select a report.
+
+# Patient payment status
+billing.patientPaymentStatus.outstanding=Outstanding bill(s) present
+billing.patientPaymentStatus.noOutstanding=No outstanding bills

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -337,4 +337,14 @@
 		</constructor-arg>
 	</bean>
 
+	<bean id="defaultPatientPaymentStatusResolver"
+	      class="org.openmrs.module.billing.api.impl.DefaultPatientPaymentStatusResolver">
+		<constructor-arg ref="billService"/>
+	</bean>
+
+	<bean id="patientPaymentStatusResolverFactory"
+	      class="org.openmrs.module.billing.api.PatientPaymentStatusResolverFactory">
+		<constructor-arg ref="defaultPatientPaymentStatusResolver"/>
+	</bean>
+
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -343,8 +343,6 @@
 	</bean>
 
 	<bean id="patientPaymentStatusResolverFactory"
-	      class="org.openmrs.module.billing.api.PatientPaymentStatusResolverFactory">
-		<constructor-arg ref="defaultPatientPaymentStatusResolver"/>
-	</bean>
+	      class="org.openmrs.module.billing.api.PatientPaymentStatusResolverFactory"/>
 
 </beans>

--- a/api/src/test/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactoryTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactoryTest.java
@@ -1,0 +1,164 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmrs.Patient;
+import org.openmrs.api.APIException;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.ModuleSettings;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+
+public class PatientPaymentStatusResolverFactoryTest {
+	
+	private AdministrationService administrationService;
+	
+	private PatientPaymentStatusResolver defaultResolver;
+	
+	private PatientPaymentStatusResolverFactory factory;
+	
+	private MockedStatic<Context> contextMock;
+	
+	@BeforeEach
+	public void setUp() {
+		administrationService = mock(AdministrationService.class);
+		defaultResolver = mock(PatientPaymentStatusResolver.class);
+		contextMock = mockStatic(Context.class);
+		contextMock.when(Context::getAdministrationService).thenReturn(administrationService);
+		factory = new PatientPaymentStatusResolverFactory(defaultResolver);
+	}
+	
+	@AfterEach
+	public void tearDown() {
+		if (contextMock != null) {
+			contextMock.close();
+		}
+	}
+	
+	@Test
+	public void getResolver_shouldReturnDefaultWhenGpIsBlank() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER)).thenReturn("");
+		assertSame(defaultResolver, factory.getResolver());
+	}
+	
+	@Test
+	public void getResolver_shouldReturnDefaultWhenGpIsNull() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER)).thenReturn(null);
+		assertSame(defaultResolver, factory.getResolver());
+	}
+	
+	@Test
+	public void getResolver_shouldInstantiateAndReturnConfiguredResolver() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(StubResolverA.class.getName());
+		
+		PatientPaymentStatusResolver result = factory.getResolver();
+		
+		assertNotSame(defaultResolver, result);
+		assertInstanceOf(StubResolverA.class, result);
+	}
+	
+	@Test
+	public void getResolver_shouldReturnSameInstanceOnSubsequentCalls() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(StubResolverA.class.getName());
+		
+		assertSame(factory.getResolver(), factory.getResolver());
+	}
+	
+	@Test
+	public void getResolver_shouldReinstantiateWhenGpValueChanges() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(StubResolverA.class.getName(), StubResolverB.class.getName());
+		
+		PatientPaymentStatusResolver first = factory.getResolver();
+		PatientPaymentStatusResolver second = factory.getResolver();
+		
+		assertInstanceOf(StubResolverA.class, first);
+		assertInstanceOf(StubResolverB.class, second);
+		assertNotSame(first, second);
+	}
+	
+	@Test
+	public void getResolver_shouldRevertToDefaultWhenGpIsClearedAfterBeingSet() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(StubResolverA.class.getName(), "");
+		
+		assertInstanceOf(StubResolverA.class, factory.getResolver());
+		assertSame(defaultResolver, factory.getResolver());
+	}
+	
+	@Test
+	public void getResolver_shouldThrowApiExceptionWhenClassNotFound() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn("does.not.exist.Resolver");
+		
+		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
+		assertTrue(ex.getMessage().contains("does.not.exist.Resolver"));
+	}
+	
+	@Test
+	public void getResolver_shouldThrowApiExceptionWhenClassDoesNotImplementInterface() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(String.class.getName());
+		
+		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
+		assertTrue(ex.getMessage().contains("does not implement"));
+	}
+	
+	@Test
+	public void getResolver_shouldThrowApiExceptionWhenClassHasNoNoArgConstructor() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
+		        .thenReturn(NoNoArgCtorResolver.class.getName());
+		
+		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
+		assertTrue(ex.getMessage().contains(NoNoArgCtorResolver.class.getName()));
+	}
+	
+	public static class StubResolverA implements PatientPaymentStatusResolver {
+		
+		@Override
+		public PatientPaymentStatusResult resolve(Patient patient) {
+			return null;
+		}
+	}
+	
+	public static class StubResolverB implements PatientPaymentStatusResolver {
+		
+		@Override
+		public PatientPaymentStatusResult resolve(Patient patient) {
+			return null;
+		}
+	}
+	
+	public static class NoNoArgCtorResolver implements PatientPaymentStatusResolver {
+		
+		public NoNoArgCtorResolver(String requiresArg) {
+		}
+		
+		@Override
+		public PatientPaymentStatusResult resolve(Patient patient) {
+			return null;
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactoryTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/PatientPaymentStatusResolverFactoryTest.java
@@ -9,14 +9,15 @@
  */
 package org.openmrs.module.billing.api;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,13 +28,12 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.ModuleSettings;
+import org.openmrs.module.billing.api.impl.DefaultPatientPaymentStatusResolver;
 import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
 
 public class PatientPaymentStatusResolverFactoryTest {
 	
 	private AdministrationService administrationService;
-	
-	private PatientPaymentStatusResolver defaultResolver;
 	
 	private PatientPaymentStatusResolverFactory factory;
 	
@@ -42,10 +42,9 @@ public class PatientPaymentStatusResolverFactoryTest {
 	@BeforeEach
 	public void setUp() {
 		administrationService = mock(AdministrationService.class);
-		defaultResolver = mock(PatientPaymentStatusResolver.class);
 		contextMock = mockStatic(Context.class);
 		contextMock.when(Context::getAdministrationService).thenReturn(administrationService);
-		factory = new PatientPaymentStatusResolverFactory(defaultResolver);
+		factory = new PatientPaymentStatusResolverFactory();
 	}
 	
 	@AfterEach
@@ -56,83 +55,67 @@ public class PatientPaymentStatusResolverFactoryTest {
 	}
 	
 	@Test
-	public void getResolver_shouldReturnDefaultWhenGpIsBlank() {
+	public void getResolver_shouldReturnRegisteredDefaultWhenGpIsBlank() {
+		DefaultPatientPaymentStatusResolver registeredDefault = new DefaultPatientPaymentStatusResolver(null);
 		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER)).thenReturn("");
-		assertSame(defaultResolver, factory.getResolver());
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Collections.singletonList(registeredDefault));
+		
+		assertSame(registeredDefault, factory.getResolver());
 	}
 	
 	@Test
-	public void getResolver_shouldReturnDefaultWhenGpIsNull() {
+	public void getResolver_shouldReturnRegisteredDefaultWhenGpIsNull() {
+		DefaultPatientPaymentStatusResolver registeredDefault = new DefaultPatientPaymentStatusResolver(null);
 		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER)).thenReturn(null);
-		assertSame(defaultResolver, factory.getResolver());
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Collections.singletonList(registeredDefault));
+		
+		assertSame(registeredDefault, factory.getResolver());
 	}
 	
 	@Test
-	public void getResolver_shouldInstantiateAndReturnConfiguredResolver() {
+	public void getResolver_shouldReturnRegisteredResolverWhenGpMatchesClassName() {
+		StubResolverA registered = new StubResolverA();
 		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
 		        .thenReturn(StubResolverA.class.getName());
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Collections.singletonList(registered));
 		
-		PatientPaymentStatusResolver result = factory.getResolver();
-		
-		assertNotSame(defaultResolver, result);
-		assertInstanceOf(StubResolverA.class, result);
+		assertSame(registered, factory.getResolver());
 	}
 	
 	@Test
-	public void getResolver_shouldReturnSameInstanceOnSubsequentCalls() {
+	public void getResolver_shouldPickMatchingResolverFromMultipleRegistered() {
+		StubResolverA a = new StubResolverA();
+		StubResolverB b = new StubResolverB();
 		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
-		        .thenReturn(StubResolverA.class.getName());
+		        .thenReturn(StubResolverB.class.getName());
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Arrays.asList(a, b));
 		
-		assertSame(factory.getResolver(), factory.getResolver());
+		assertSame(b, factory.getResolver());
 	}
 	
 	@Test
-	public void getResolver_shouldReinstantiateWhenGpValueChanges() {
-		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
-		        .thenReturn(StubResolverA.class.getName(), StubResolverB.class.getName());
-		
-		PatientPaymentStatusResolver first = factory.getResolver();
-		PatientPaymentStatusResolver second = factory.getResolver();
-		
-		assertInstanceOf(StubResolverA.class, first);
-		assertInstanceOf(StubResolverB.class, second);
-		assertNotSame(first, second);
-	}
-	
-	@Test
-	public void getResolver_shouldRevertToDefaultWhenGpIsClearedAfterBeingSet() {
-		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
-		        .thenReturn(StubResolverA.class.getName(), "");
-		
-		assertInstanceOf(StubResolverA.class, factory.getResolver());
-		assertSame(defaultResolver, factory.getResolver());
-	}
-	
-	@Test
-	public void getResolver_shouldThrowApiExceptionWhenClassNotFound() {
+	public void getResolver_shouldThrowApiExceptionWhenNoRegisteredResolverMatches() {
 		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
 		        .thenReturn("does.not.exist.Resolver");
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Collections.singletonList(new StubResolverA()));
 		
 		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
 		assertTrue(ex.getMessage().contains("does.not.exist.Resolver"));
 	}
 	
 	@Test
-	public void getResolver_shouldThrowApiExceptionWhenClassDoesNotImplementInterface() {
-		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
-		        .thenReturn(String.class.getName());
+	public void getResolver_shouldThrowApiExceptionWhenDefaultNotRegistered() {
+		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER)).thenReturn("");
+		contextMock.when(() -> Context.getRegisteredComponents(PatientPaymentStatusResolver.class))
+		        .thenReturn(Collections.emptyList());
 		
 		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
-		assertTrue(ex.getMessage().contains("does not implement"));
-	}
-	
-	@Test
-	public void getResolver_shouldThrowApiExceptionWhenClassHasNoNoArgConstructor() {
-		when(administrationService.getGlobalProperty(ModuleSettings.PATIENT_PAYMENT_STATUS_RESOLVER))
-		        .thenReturn(NoNoArgCtorResolver.class.getName());
-		
-		APIException ex = assertThrows(APIException.class, () -> factory.getResolver());
-		assertTrue(ex.getMessage().contains(NoNoArgCtorResolver.class.getName()));
+		assertTrue(ex.getMessage().contains(DefaultPatientPaymentStatusResolver.class.getName()));
 	}
 	
 	public static class StubResolverA implements PatientPaymentStatusResolver {
@@ -144,17 +127,6 @@ public class PatientPaymentStatusResolverFactoryTest {
 	}
 	
 	public static class StubResolverB implements PatientPaymentStatusResolver {
-		
-		@Override
-		public PatientPaymentStatusResult resolve(Patient patient) {
-			return null;
-		}
-	}
-	
-	public static class NoNoArgCtorResolver implements PatientPaymentStatusResolver {
-		
-		public NoNoArgCtorResolver(String requiresArg) {
-		}
 		
 		@Override
 		public PatientPaymentStatusResult resolve(Patient patient) {

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
@@ -1,0 +1,129 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmrs.Patient;
+import org.openmrs.module.billing.api.BillService;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.PatientPaymentStatus;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultPatientPaymentStatusResolverTest {
+	
+	private static final String PATIENT_UUID = "patient-uuid-123";
+	
+	@Mock
+	private BillService billService;
+	
+	private DefaultPatientPaymentStatusResolver resolver;
+	
+	private Patient patient;
+	
+	@BeforeEach
+	public void setUp() {
+		resolver = new DefaultPatientPaymentStatusResolver(billService);
+		patient = new Patient();
+		patient.setUuid(PATIENT_UUID);
+	}
+	
+	@Test
+	public void resolve_shouldReturnPaidWhenPatientHasNoBills() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null)).thenReturn(Collections.emptyList());
+		
+		PatientPaymentStatusResult result = resolver.resolve(patient);
+		
+		assertEquals(PatientPaymentStatus.PAID, result.getStatus());
+		assertEquals("No outstanding bills", result.getReason());
+	}
+	
+	@Test
+	public void resolve_shouldReturnUnpaidWhenAnyBillIsPending() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
+		        .thenReturn(Collections.singletonList(bill(BillStatus.PENDING, false)));
+		
+		PatientPaymentStatusResult result = resolver.resolve(patient);
+		
+		assertEquals(PatientPaymentStatus.UNPAID, result.getStatus());
+		assertEquals("Outstanding bill(s) present", result.getReason());
+	}
+	
+	@Test
+	public void resolve_shouldReturnUnpaidWhenAnyBillIsPosted() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
+		        .thenReturn(Collections.singletonList(bill(BillStatus.POSTED, false)));
+		
+		assertEquals(PatientPaymentStatus.UNPAID, resolver.resolve(patient).getStatus());
+	}
+	
+	@Test
+	public void resolve_shouldReturnPaidWhenAllBillsArePaid() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
+		        .thenReturn(Arrays.asList(bill(BillStatus.PAID, false), bill(BillStatus.PAID, false)));
+		
+		assertEquals(PatientPaymentStatus.PAID, resolver.resolve(patient).getStatus());
+	}
+	
+	@Test
+	public void resolve_shouldReturnPaidForExemptedAndRefundedBills() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
+		        .thenReturn(Arrays.asList(bill(BillStatus.EXEMPTED, false), bill(BillStatus.REFUNDED, false),
+		            bill(BillStatus.PARTIALLY_REFUNDED, false), bill(BillStatus.CANCELLED, false)));
+		
+		assertEquals(PatientPaymentStatus.PAID, resolver.resolve(patient).getStatus());
+	}
+	
+	@Test
+	public void resolve_shouldIgnoreVoidedPendingBills() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
+		        .thenReturn(Collections.singletonList(bill(BillStatus.PENDING, true)));
+		
+		assertEquals(PatientPaymentStatus.PAID, resolver.resolve(patient).getStatus());
+	}
+	
+	@Test
+	public void resolve_shouldReturnUnpaidWhenMixHasPendingAlongsidePaid() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null)).thenReturn(
+		    Arrays.asList(bill(BillStatus.PAID, false), bill(BillStatus.PENDING, false), bill(BillStatus.PAID, false)));
+		
+		assertEquals(PatientPaymentStatus.UNPAID, resolver.resolve(patient).getStatus());
+	}
+	
+	@Test
+	public void resolve_shouldPassPatientUuidToBillService() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null)).thenReturn(Collections.emptyList());
+		
+		resolver.resolve(patient);
+		
+		verify(billService).getBillsByPatientUuid(eq(PATIENT_UUID), isNull());
+	}
+	
+	private Bill bill(BillStatus status, boolean voided) {
+		Bill bill = new Bill();
+		bill.setStatus(status);
+		bill.setVoided(voided);
+		return bill;
+	}
+}

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
@@ -12,18 +12,25 @@ package org.openmrs.module.billing.api.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillStatus;
@@ -42,11 +49,28 @@ public class DefaultPatientPaymentStatusResolverTest {
 	
 	private Patient patient;
 	
+	private MockedStatic<Context> contextMock;
+	
 	@BeforeEach
 	public void setUp() {
+		MessageSourceService messageSourceService = mock(MessageSourceService.class);
+		lenient().when(messageSourceService.getMessage(DefaultPatientPaymentStatusResolver.MSG_OUTSTANDING))
+		        .thenReturn("Outstanding bill(s) present");
+		lenient().when(messageSourceService.getMessage(DefaultPatientPaymentStatusResolver.MSG_NO_OUTSTANDING))
+		        .thenReturn("No outstanding bills");
+		contextMock = mockStatic(Context.class);
+		contextMock.when(Context::getMessageSourceService).thenReturn(messageSourceService);
+		
 		resolver = new DefaultPatientPaymentStatusResolver(billService);
 		patient = new Patient();
 		patient.setUuid(PATIENT_UUID);
+	}
+	
+	@AfterEach
+	public void tearDown() {
+		if (contextMock != null) {
+			contextMock.close();
+		}
 	}
 	
 	@Test

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/controller/PatientPaymentStatusController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/controller/PatientPaymentStatusController.java
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.web.rest.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.PatientPaymentStatusResolverFactory;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/rest/" + RestConstants.VERSION_1 + "/billing/patientPaymentStatus")
+@RequiredArgsConstructor
+public class PatientPaymentStatusController {
+	
+	private final PatientPaymentStatusResolverFactory patientPaymentStatusResolverFactory;
+	
+	@GetMapping("{patientUuid}")
+	public ResponseEntity<PatientPaymentStatusResult> getPatientPaymentStatus(@PathVariable String patientUuid) {
+		Patient patient = Context.getPatientService().getPatientByUuid(patientUuid);
+		
+		if (patient == null) {
+			return ResponseEntity.notFound().build();
+		}
+		
+		PatientPaymentStatusResult result = patientPaymentStatusResolverFactory.getResolver().resolve(patient);
+		return ResponseEntity.ok(result);
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -173,6 +173,16 @@
 		</description>
 	</globalProperty>
 
+	<globalProperty>
+		<property>${project.parent.artifactId}.patientPaymentStatusResolver</property>
+		<description>
+			Fully qualified class name of a class implementing
+			org.openmrs.module.billing.api.PatientPaymentStatusResolver. The class must
+			have a public no-arg constructor. Leave blank to use the default resolver,
+			which derives PAID/UNPAID from existing Bill records.
+		</description>
+	</globalProperty>
+
 
 	<!-- Extensions -->
 	<!--	<extension>-->

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -176,10 +176,11 @@
 	<globalProperty>
 		<property>${project.parent.artifactId}.patientPaymentStatusResolver</property>
 		<description>
-			Fully qualified class name of a class implementing
-			org.openmrs.module.billing.api.PatientPaymentStatusResolver. The class must
-			have a public no-arg constructor. Leave blank to use the default resolver,
-			which derives PAID/UNPAID from existing Bill records.
+			Fully qualified class name of a Spring-managed bean implementing
+			org.openmrs.module.billing.api.PatientPaymentStatusResolver. The bean must
+			be registered as a component by some OpenMRS module so that
+			Context.getRegisteredComponents() can find it. Leave blank to use the
+			default resolver, which derives PAID/UNPAID from existing Bill records.
 		</description>
 	</globalProperty>
 

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/controller/PatientPaymentStatusControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/controller/PatientPaymentStatusControllerTest.java
@@ -1,0 +1,124 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.web.rest.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmrs.Patient;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.PatientPaymentStatusResolver;
+import org.openmrs.module.billing.api.PatientPaymentStatusResolverFactory;
+import org.openmrs.module.billing.api.model.PatientPaymentStatus;
+import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class PatientPaymentStatusControllerTest {
+	
+	private PatientPaymentStatusController controller;
+	
+	private PatientPaymentStatusResolverFactory factory;
+	
+	private PatientPaymentStatusResolver resolver;
+	
+	private PatientService patientService;
+	
+	private MockedStatic<Context> contextMock;
+	
+	@BeforeEach
+	public void setUp() {
+		factory = mock(PatientPaymentStatusResolverFactory.class);
+		resolver = mock(PatientPaymentStatusResolver.class);
+		patientService = mock(PatientService.class);
+		
+		contextMock = mockStatic(Context.class);
+		contextMock.when(Context::getPatientService).thenReturn(patientService);
+		
+		controller = new PatientPaymentStatusController(factory);
+	}
+	
+	@AfterEach
+	public void tearDown() {
+		if (contextMock != null) {
+			contextMock.close();
+		}
+	}
+	
+	@Test
+	public void getPatientPaymentStatus_shouldReturn404WhenPatientNotFound() {
+		when(patientService.getPatientByUuid("missing")).thenReturn(null);
+		
+		ResponseEntity<PatientPaymentStatusResult> response = controller.getPatientPaymentStatus("missing");
+		
+		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+		verifyNoInteractions(factory);
+	}
+	
+	@Test
+	public void getPatientPaymentStatus_shouldReturn200WithResolverResult() {
+		Patient patient = patientWithUuid("abc");
+		PatientPaymentStatusResult expected = PatientPaymentStatusResult.builder().status(PatientPaymentStatus.PAID)
+		        .reason("No outstanding bills").build();
+		
+		when(patientService.getPatientByUuid("abc")).thenReturn(patient);
+		when(factory.getResolver()).thenReturn(resolver);
+		when(resolver.resolve(patient)).thenReturn(expected);
+		
+		ResponseEntity<PatientPaymentStatusResult> response = controller.getPatientPaymentStatus("abc");
+		
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertSame(expected, response.getBody());
+	}
+	
+	@Test
+	public void getPatientPaymentStatus_shouldPassLookedUpPatientToResolver() {
+		Patient patient = patientWithUuid("abc");
+		
+		when(patientService.getPatientByUuid("abc")).thenReturn(patient);
+		when(factory.getResolver()).thenReturn(resolver);
+		when(resolver.resolve(patient)).thenReturn(PatientPaymentStatusResult.builder().build());
+		
+		controller.getPatientPaymentStatus("abc");
+		
+		verify(resolver).resolve(patient);
+	}
+	
+	@Test
+	public void getPatientPaymentStatus_shouldDelegateToFactoryEachCall() {
+		Patient patient = patientWithUuid("abc");
+		
+		when(patientService.getPatientByUuid("abc")).thenReturn(patient);
+		when(factory.getResolver()).thenReturn(resolver);
+		when(resolver.resolve(patient)).thenReturn(PatientPaymentStatusResult.builder().build());
+		
+		controller.getPatientPaymentStatus("abc");
+		controller.getPatientPaymentStatus("abc");
+		
+		verify(factory, times(2)).getResolver();
+	}
+	
+	private Patient patientWithUuid(String uuid) {
+		Patient patient = new Patient();
+		patient.setUuid(uuid);
+		return patient;
+	}
+}


### PR DESCRIPTION
Adds a new REST endpoint to determine whether a patient has any outstanding bills.

- GET /rest/v1/billing/patientPaymentStatus/{patientUuid} returns { status: PAID | UNPAID, reason }
- Default resolver derives status from Bill records: PENDING or POSTED (and non-voided) → UNPAID, everything else → PAID
- Pluggable via the billing.patientPaymentStatusResolver global property: set to the fully qualified class name of a Spring-registered
  PatientPaymentStatusResolver bean to override
- Returns 400 for blank UUIDs, 404 for unknown patients, 500 (logged) for resolver/config errors
- 
Ticket: https://openmrs.atlassian.net/browse/O3-5410