### PR TITLE
Update itextPdf to 8.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<openmrsPlatformVersion>2.7.8</openmrsPlatformVersion>
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
-		<itextPdfVersion>8.0.2</itextPdfVersion>
+		<itextPdfVersion>8.0.5</itextPdfVersion>
 		<stockmanagementVersion>1.4.0</stockmanagementVersion>
 		<fhir2Version>2.4.0</fhir2Version>
 		<eventVersion>4.0.0</eventVersion>


### PR DESCRIPTION
This resolves `barcodes-8.0.2.jar (pkg:maven/com.itextpdf/barcodes@8.0.2, cpe:2.3:a:itextpdf:itext:8.0.2:*:*:*:*:*:*:*): CVE-2023-6298(6.5)`