### PR TITLE
Add refundStatus filter to GET /bill and expose refunds in bill representation

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
@@ -22,6 +22,7 @@ import org.openmrs.module.billing.api.base.PagingInfo;
 import org.openmrs.module.billing.api.db.BillDAO;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillDiscount;
+import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.billing.api.search.BillSearch;
 
 import javax.annotation.Nonnull;
@@ -188,6 +189,14 @@ public class HibernateBillDAO implements BillDAO {
 			sub.select(cb.literal(1)).where(cb.equal(discountRoot.get("bill"), root),
 			    cb.equal(discountRoot.get("voided"), false),
 			    discountRoot.get("status").in(billSearch.getDiscountStatuses()));
+			predicates.add(cb.exists(sub));
+		}
+		
+		if (billSearch.getRefundStatuses() != null && !billSearch.getRefundStatuses().isEmpty()) {
+			Subquery<Integer> sub = cq.subquery(Integer.class);
+			Root<BillRefund> refundRoot = sub.from(BillRefund.class);
+			sub.select(cb.literal(1)).where(cb.equal(refundRoot.get("bill"), root),
+			    cb.equal(refundRoot.get("voided"), false), refundRoot.get("status").in(billSearch.getRefundStatuses()));
 			predicates.add(cb.exists(sub));
 		}
 		

--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
@@ -46,6 +46,10 @@ import static org.openmrs.module.billing.api.db.hibernate.PagingUtil.applyPaging
 @AllArgsConstructor
 public class HibernateBillDAO implements BillDAO {
 	
+	private static final String FIELD_STATUS = "status";
+	
+	private static final String FIELD_VOIDED = "voided";
+	
 	@Setter(AccessLevel.PROTECTED)
 	private SessionFactory sessionFactory;
 	
@@ -153,14 +157,8 @@ public class HibernateBillDAO implements BillDAO {
 			predicates.add(cb.equal(root.get("patient").get("uuid"), billSearch.getPatientUuid()));
 		}
 		
-		if (billSearch.getPatientName() != null && !billSearch.getPatientName().trim().isEmpty()) {
-			List<Patient> matchingPatients = Context.getRegisteredComponent("patientDAO", HibernatePatientDAO.class)
-			        .getPatients(billSearch.getPatientName(), 0, null);
-			if (matchingPatients != null && !matchingPatients.isEmpty()) {
-				predicates.add(root.get("patient").in(matchingPatients));
-			} else {
-				predicates.add(cb.disjunction());
-			}
+		if (StringUtils.isNotBlank(billSearch.getPatientName())) {
+			predicates.add(buildPatientNamePredicate(cb, root, billSearch.getPatientName()));
 		}
 		
 		if (StringUtils.isNotEmpty(billSearch.getCashierUuid())) {
@@ -176,19 +174,19 @@ public class HibernateBillDAO implements BillDAO {
 		}
 		
 		if (billSearch.getStatuses() != null && !billSearch.getStatuses().isEmpty()) {
-			predicates.add(root.get("status").in(billSearch.getStatuses()));
+			predicates.add(root.get(FIELD_STATUS).in(billSearch.getStatuses()));
 		}
 		
 		if (!Boolean.TRUE.equals(billSearch.getIncludeVoided())) {
-			predicates.add(cb.equal(root.get("voided"), false));
+			predicates.add(cb.equal(root.get(FIELD_VOIDED), false));
 		}
 		
 		if (billSearch.getDiscountStatuses() != null && !billSearch.getDiscountStatuses().isEmpty()) {
 			Subquery<Integer> sub = cq.subquery(Integer.class);
 			Root<BillDiscount> discountRoot = sub.from(BillDiscount.class);
 			sub.select(cb.literal(1)).where(cb.equal(discountRoot.get("bill"), root),
-			    cb.equal(discountRoot.get("voided"), false),
-			    discountRoot.get("status").in(billSearch.getDiscountStatuses()));
+			    cb.equal(discountRoot.get(FIELD_VOIDED), false),
+			    discountRoot.get(FIELD_STATUS).in(billSearch.getDiscountStatuses()));
 			predicates.add(cb.exists(sub));
 		}
 		
@@ -196,11 +194,21 @@ public class HibernateBillDAO implements BillDAO {
 			Subquery<Integer> sub = cq.subquery(Integer.class);
 			Root<BillRefund> refundRoot = sub.from(BillRefund.class);
 			sub.select(cb.literal(1)).where(cb.equal(refundRoot.get("bill"), root),
-			    cb.equal(refundRoot.get("voided"), false), refundRoot.get("status").in(billSearch.getRefundStatuses()));
+			    cb.equal(refundRoot.get(FIELD_VOIDED), false),
+			    refundRoot.get(FIELD_STATUS).in(billSearch.getRefundStatuses()));
 			predicates.add(cb.exists(sub));
 		}
 		
 		return predicates;
+	}
+	
+	private Predicate buildPatientNamePredicate(CriteriaBuilder cb, Root<Bill> root, String patientName) {
+		List<Patient> matchingPatients = Context.getRegisteredComponent("patientDAO", HibernatePatientDAO.class)
+		        .getPatients(patientName, 0, null);
+		if (matchingPatients != null && !matchingPatients.isEmpty()) {
+			return root.get("patient").in(matchingPatients);
+		}
+		return cb.disjunction();
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/model/Bill.java
@@ -70,6 +70,24 @@ public class Bill extends BaseOpenmrsData {
 	private Set<BillRefund> refunds;
 	
 	/**
+	 * Returns every non-voided refund on this bill. Voided rows are excluded — for the full audit
+	 * history, query {@code BillRefundService.getRefundsByBillId} (or the equivalent REST search at
+	 * {@code /billRefund?bill=<uuid>}).
+	 */
+	public List<BillRefund> getActiveRefunds() {
+		if (refunds == null) {
+			return Collections.emptyList();
+		}
+		List<BillRefund> active = new ArrayList<>();
+		for (BillRefund r : refunds) {
+			if (r != null && !r.getVoided()) {
+				active.add(r);
+			}
+		}
+		return active;
+	}
+	
+	/**
 	 * Returns every non-voided discount on this bill (bill-level and line-item scoped). Voided rows are
 	 * excluded — for the full audit history, query {@code BillDiscountService.getDiscountsByBillId} (or
 	 * the equivalent REST search at {@code /billDiscount?bill=<uuid>}).

--- a/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.DiscountStatus;
+import org.openmrs.module.billing.api.model.RefundStatus;
 
 /**
  * A search criteria holder for {@link org.openmrs.module.billing.api.model.Bill} queries. This
@@ -42,6 +43,8 @@ public class BillSearch {
 	private List<BillStatus> statuses;
 	
 	private List<DiscountStatus> discountStatuses;
+	
+	private List<RefundStatus> refundStatuses;
 	
 	private String patientName;
 	

--- a/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
@@ -30,6 +30,7 @@ import org.openmrs.module.billing.api.db.BillDAO;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.DiscountStatus;
+import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.search.BillSearch;
 import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
@@ -373,6 +374,39 @@ public class HibernateBillDAOTest extends BaseModuleContextSensitiveTest {
 		assertEquals(1, countOf1004, "Bill 1004 matches both PENDING and APPROVED discounts but must appear exactly once");
 		assertFalse(resultUuids.contains("b3000000-0000-0000-0000-000000000003"),
 		    "Bill 1003 has only a REJECTED discount — must not appear for PENDING|APPROVED filter");
+	}
+	
+	@Test
+	public void getBills_shouldFilterByRefundStatus() {
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "BillRefundStatusFilterTest.xml");
+		BillSearch search = BillSearch.builder().refundStatuses(Arrays.asList(RefundStatus.REQUESTED)).build();
+		List<Bill> results = billDAO.getBills(search, null);
+		List<String> resultUuids = uuids(results);
+		
+		assertTrue(resultUuids.contains("c1000000-0000-0000-0000-000000000001"), "Expected bill 2001 (REQUESTED refund)");
+		assertTrue(resultUuids.contains("c4000000-0000-0000-0000-000000000004"),
+		    "Expected bill 2004 (REQUESTED + COMPLETED refunds)");
+		assertFalse(resultUuids.contains("c5000000-0000-0000-0000-000000000005"),
+		    "Bill 2005 has only a voided REQUESTED refund — must be excluded");
+		assertFalse(resultUuids.contains("c6000000-0000-0000-0000-000000000006"),
+		    "Bill 2006 has no refunds at all — must be excluded by the EXISTS predicate");
+	}
+	
+	@Test
+	public void getBills_shouldNotDuplicateBillsWithMultipleMatchingRefunds() {
+		executeDataSet(TestConstants.BASE_DATASET_DIR + "BillRefundStatusFilterTest.xml");
+		BillSearch search = BillSearch.builder()
+		        .refundStatuses(Arrays.asList(RefundStatus.REQUESTED, RefundStatus.COMPLETED)).build();
+		List<Bill> results = billDAO.getBills(search, null);
+		List<String> resultUuids = uuids(results);
+		
+		long countOf2004 = results.stream().filter(b -> "c4000000-0000-0000-0000-000000000004".equals(b.getUuid())).count();
+		
+		assertEquals(1, countOf2004, "Bill 2004 matches both REQUESTED and COMPLETED refunds but must appear exactly once");
+		assertFalse(resultUuids.contains("c3000000-0000-0000-0000-000000000003"),
+		    "Bill 2003 has only a REJECTED refund — must not appear for REQUESTED|COMPLETED filter");
+		assertFalse(resultUuids.contains("c5000000-0000-0000-0000-000000000005"),
+		    "Bill 2005 has only a voided REQUESTED refund — must be excluded even in multi-status query");
 	}
 	
 	private List<String> uuids(List<Bill> bills) {

--- a/api/src/test/resources/org/openmrs/module/billing/api/include/BillRefundStatusFilterTest.xml
+++ b/api/src/test/resources/org/openmrs/module/billing/api/include/BillRefundStatusFilterTest.xml
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+	<!-- Five bills (2001–2005) used exclusively to test getBills refund-status filtering.
+	     Uses bill_id range 2001–2005 to avoid colliding with BillTest.xml (0–2),
+	     BillDiscountTest.xml (100–200), and BillDiscountStatusFilterTest.xml (1001–1005). -->
+
+	<!-- bill 2001 — one REQUESTED refund (non-voided) -->
+	<cashier_bill bill_id="2001" receipt_number="refund-filter-2001" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c1000000-0000-0000-0000-000000000001" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2010" bill_id="2001" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002010"/>
+
+	<!-- bill 2002 — one APPROVED refund (non-voided) -->
+	<cashier_bill bill_id="2002" receipt_number="refund-filter-2002" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c2000000-0000-0000-0000-000000000002" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2020" bill_id="2002" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002020"/>
+
+	<!-- bill 2003 — one REJECTED refund (non-voided) -->
+	<cashier_bill bill_id="2003" receipt_number="refund-filter-2003" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c3000000-0000-0000-0000-000000000003" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2030" bill_id="2003" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002030"/>
+
+	<!-- bill 2004 — one REQUESTED + one COMPLETED refund (both non-voided) -->
+	<cashier_bill bill_id="2004" receipt_number="refund-filter-2004" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c4000000-0000-0000-0000-000000000004" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2040" bill_id="2004" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002040"/>
+	<cashier_bill_line_item bill_line_item_id="2041" bill_id="2004" item_id="0" price="50.00" price_name="default"
+	                        quantity="1" line_item_order="1" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002041"/>
+
+	<!-- bill 2005 — one REQUESTED refund that is voided -->
+	<cashier_bill bill_id="2005" receipt_number="refund-filter-2005" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c5000000-0000-0000-0000-000000000005" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2050" bill_id="2005" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002050"/>
+
+	<!-- bill 2006 — no refund rows at all; must be excluded by any refundStatus filter -->
+	<cashier_bill bill_id="2006" receipt_number="refund-filter-2006" provider_id="0" patient_id="0"
+	              cash_point_id="0" status="PENDING"
+	              creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	              uuid="c6000000-0000-0000-0000-000000000006" receipt_printed="0"/>
+	<cashier_bill_line_item bill_line_item_id="2060" bill_id="2006" item_id="0" price="100.00" price_name="default"
+	                        quantity="1" line_item_order="0" status="PENDING"
+	                        creator="1" date_created="2012-01-01 00:00:00.0" voided="false"
+	                        uuid="f1000000-0000-0000-0000-000000002060"/>
+
+	<!-- bill_refund rows. A row with bill_line_item_id is listed FIRST so DbUnit column-sensing
+	     picks up the optional column for all subsequent rows. -->
+
+	<!-- bill 2003: REJECTED line-item refund (listed first to prime column sensing) -->
+	<bill_refund bill_refund_id="2003" bill_id="2003" bill_line_item_id="2030"
+	             refund_amount="20.00" reason="Rejected refund request" refund_status="REJECTED"
+	             initiator_id="1" approver_id="5506"
+	             creator="1" date_created="2012-01-02 00:00:00.0" voided="false"
+	             uuid="a1000000-0000-0000-0000-000000002003"/>
+
+	<!-- bill 2001: REQUESTED bill-level refund -->
+	<bill_refund bill_refund_id="2001" bill_id="2001"
+	             refund_amount="10.00" reason="Awaiting approval" refund_status="REQUESTED"
+	             initiator_id="1"
+	             creator="1" date_created="2012-01-02 00:00:00.0" voided="false"
+	             uuid="a1000000-0000-0000-0000-000000002001"/>
+
+	<!-- bill 2002: APPROVED bill-level refund -->
+	<bill_refund bill_refund_id="2002" bill_id="2002"
+	             refund_amount="15.00" reason="Approved refund" refund_status="APPROVED"
+	             initiator_id="1" approver_id="5506"
+	             creator="1" date_created="2012-01-02 00:00:00.0" voided="false"
+	             uuid="a1000000-0000-0000-0000-000000002002"/>
+
+	<!-- bill 2004: REQUESTED line-item refund -->
+	<bill_refund bill_refund_id="2004" bill_id="2004" bill_line_item_id="2040"
+	             refund_amount="5.00" reason="Pending line item refund" refund_status="REQUESTED"
+	             initiator_id="1"
+	             creator="1" date_created="2012-01-02 00:00:00.0" voided="false"
+	             uuid="a1000000-0000-0000-0000-000000002004"/>
+
+	<!-- bill 2004: COMPLETED line-item refund -->
+	<bill_refund bill_refund_id="2005" bill_id="2004" bill_line_item_id="2041"
+	             refund_amount="5.00" reason="Completed line item refund" refund_status="COMPLETED"
+	             initiator_id="1" approver_id="5506" completer_id="1"
+	             creator="1" date_created="2012-01-02 00:00:00.0" voided="false"
+	             uuid="a1000000-0000-0000-0000-000000002005"/>
+
+	<!-- bill 2005: REQUESTED refund — voided -->
+	<bill_refund bill_refund_id="2006" bill_id="2005" bill_line_item_id="2050"
+	             refund_amount="10.00" reason="Will be voided" refund_status="REQUESTED"
+	             initiator_id="1"
+	             creator="1" date_created="2012-01-02 00:00:00.0"
+	             voided="true" voided_by="1" date_voided="2012-01-03 00:00:00.0" void_reason="Test void"
+	             uuid="a1000000-0000-0000-0000-000000002006"/>
+</dataset>

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -39,6 +39,7 @@ import org.openmrs.module.billing.api.model.Payment;
 import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.model.Timesheet;
 import org.openmrs.module.billing.api.search.BillSearch;
+import org.openmrs.module.billing.api.util.PrivilegeConstants;
 import org.openmrs.module.billing.api.util.RoundingUtil;
 import org.openmrs.module.billing.web.base.resource.BaseRestDataResource;
 import org.openmrs.module.billing.web.base.resource.PagingUtil;
@@ -123,6 +124,9 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 	
 	@PropertyGetter("refunds")
 	public List<BillRefund> getActiveRefunds(Bill bill) {
+		if (!Context.hasPrivilege(PrivilegeConstants.VIEW_REFUNDS)) {
+			return java.util.Collections.emptyList();
+		}
 		return bill.getActiveRefunds();
 	}
 	
@@ -354,6 +358,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		
 		String refundStatus = context.getRequest().getParameter("refundStatus");
 		if (StringUtils.isNotBlank(refundStatus)) {
+			Context.requirePrivilege(PrivilegeConstants.VIEW_REFUNDS);
 			List<RefundStatus> refundStatuses = parseRefundStatuses(refundStatus);
 			if (refundStatuses.isEmpty()) {
 				throw new InvalidSearchException("refundStatus parameter contained no valid values");

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -349,31 +349,12 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		
 		String discountStatus = context.getRequest().getParameter("discountStatus");
 		if (StringUtils.isNotBlank(discountStatus)) {
-			List<DiscountStatus> discountStatuses = Arrays.stream(discountStatus.split(",")).map(String::trim)
-			        .filter(StringUtils::isNotBlank).map(s -> {
-				        try {
-					        return DiscountStatus.valueOf(s.toUpperCase(Locale.ROOT));
-				        }
-				        catch (IllegalArgumentException e) {
-					        throw new InvalidSearchException("Invalid discountStatus '" + s + "'. Allowed values: "
-					                + Arrays.toString(DiscountStatus.values()));
-				        }
-			        }).collect(Collectors.toList());
-			billSearch.setDiscountStatuses(discountStatuses);
+			billSearch.setDiscountStatuses(parseDiscountStatuses(discountStatus));
 		}
 		
 		String refundStatus = context.getRequest().getParameter("refundStatus");
 		if (StringUtils.isNotBlank(refundStatus)) {
-			List<RefundStatus> refundStatuses = Arrays.stream(refundStatus.split(",")).map(String::trim)
-			        .filter(StringUtils::isNotBlank).map(s -> {
-				        try {
-					        return RefundStatus.valueOf(s.toUpperCase(Locale.ROOT));
-				        }
-				        catch (IllegalArgumentException e) {
-					        throw new InvalidSearchException("Invalid refundStatus '" + s + "'. Allowed values: "
-					                + Arrays.toString(RefundStatus.values()));
-				        }
-			        }).collect(Collectors.toList());
+			List<RefundStatus> refundStatuses = parseRefundStatuses(refundStatus);
 			if (refundStatuses.isEmpty()) {
 				throw new InvalidSearchException("refundStatus parameter contained no valid values");
 			}
@@ -386,5 +367,29 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		}
 		
 		return billSearch;
+	}
+	
+	private List<DiscountStatus> parseDiscountStatuses(String param) {
+		return Arrays.stream(param.split(",")).map(String::trim).filter(StringUtils::isNotBlank).map(s -> {
+			try {
+				return DiscountStatus.valueOf(s.toUpperCase(Locale.ROOT));
+			}
+			catch (IllegalArgumentException e) {
+				throw new InvalidSearchException(
+				        "Invalid discountStatus '" + s + "'. Allowed values: " + Arrays.toString(DiscountStatus.values()));
+			}
+		}).collect(Collectors.toList());
+	}
+	
+	private List<RefundStatus> parseRefundStatuses(String param) {
+		return Arrays.stream(param.split(",")).map(String::trim).filter(StringUtils::isNotBlank).map(s -> {
+			try {
+				return RefundStatus.valueOf(s.toUpperCase(Locale.ROOT));
+			}
+			catch (IllegalArgumentException e) {
+				throw new InvalidSearchException(
+				        "Invalid refundStatus '" + s + "'. Allowed values: " + Arrays.toString(RefundStatus.values()));
+			}
+		}).collect(Collectors.toList());
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -31,10 +31,12 @@ import org.openmrs.module.billing.api.base.PagingInfo;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillDiscount;
 import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.DiscountStatus;
 import org.openmrs.module.billing.api.model.Payment;
+import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.model.Timesheet;
 import org.openmrs.module.billing.api.search.BillSearch;
 import org.openmrs.module.billing.api.util.RoundingUtil;
@@ -81,6 +83,7 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 			description.addProperty("status");
 			description.addProperty("adjustmentReason");
 			description.addProperty("discounts", Representation.DEFAULT);
+			description.addProperty("refunds", Representation.DEFAULT);
 			description.addProperty("total");
 			description.addProperty("amountAfterDiscount");
 			description.addProperty("uuid");
@@ -116,6 +119,11 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 	@PropertyGetter("discounts")
 	public List<BillDiscount> getActiveDiscounts(Bill bill) {
 		return bill.getActiveDiscounts();
+	}
+	
+	@PropertyGetter("refunds")
+	public List<BillRefund> getActiveRefunds(Bill bill) {
+		return bill.getActiveRefunds();
 	}
 	
 	@PropertySetter("lineItems")
@@ -352,6 +360,24 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 				        }
 			        }).collect(Collectors.toList());
 			billSearch.setDiscountStatuses(discountStatuses);
+		}
+		
+		String refundStatus = context.getRequest().getParameter("refundStatus");
+		if (StringUtils.isNotBlank(refundStatus)) {
+			List<RefundStatus> refundStatuses = Arrays.stream(refundStatus.split(",")).map(String::trim)
+			        .filter(StringUtils::isNotBlank).map(s -> {
+				        try {
+					        return RefundStatus.valueOf(s.toUpperCase(Locale.ROOT));
+				        }
+				        catch (IllegalArgumentException e) {
+					        throw new InvalidSearchException("Invalid refundStatus '" + s + "'. Allowed values: "
+					                + Arrays.toString(RefundStatus.values()));
+				        }
+			        }).collect(Collectors.toList());
+			if (refundStatuses.isEmpty()) {
+				throw new InvalidSearchException("refundStatus parameter contained no valid values");
+			}
+			billSearch.setRefundStatuses(refundStatuses);
 		}
 		
 		String includeAll = context.getRequest().getParameter("includeAll");

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
@@ -41,11 +41,15 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.BillService;
 import org.openmrs.module.billing.api.base.PagingInfo;
 import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.billing.api.model.BillStatus;
 import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.DiscountStatus;
+import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.search.BillSearch;
 import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.InvalidSearchException;
 
 /**
@@ -86,13 +90,28 @@ public class BillResourceTest {
 		}
 	}
 	
-	/**
-	 * Builds a mocked {@link RequestContext} with the given discountStatus request parameter value
-	 * (null means the parameter is absent).
-	 */
 	private RequestContext buildContext(String discountStatusParam) {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 		org.mockito.Mockito.when(req.getParameter("discountStatus")).thenReturn(discountStatusParam);
+		
+		RequestContext context = mock(RequestContext.class);
+		org.mockito.Mockito.when(context.getRequest()).thenReturn(req);
+		org.mockito.Mockito.when(context.getStartIndex()).thenReturn(0);
+		org.mockito.Mockito.when(context.getLimit()).thenReturn(10);
+		
+		return context;
+	}
+	
+	private BillRefund refundWithStatus(RefundStatus status, boolean voided) {
+		BillRefund refund = new BillRefund();
+		refund.setStatus(status);
+		refund.setVoided(voided);
+		return refund;
+	}
+	
+	private RequestContext buildRefundContext(String refundStatusParam) {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		org.mockito.Mockito.when(req.getParameter("refundStatus")).thenReturn(refundStatusParam);
 		
 		RequestContext context = mock(RequestContext.class);
 		org.mockito.Mockito.when(context.getRequest()).thenReturn(req);
@@ -137,6 +156,43 @@ public class BillResourceTest {
 		resource.doSearch(context);
 		
 		assertNull(capturedSearches.get(0).getDiscountStatuses());
+	}
+	
+	@Test
+	public void doSearch_shouldParseSingleRefundStatusParam() {
+		RequestContext context = buildRefundContext("REQUESTED");
+		
+		resource.doSearch(context);
+		
+		assertEquals(Collections.singletonList(RefundStatus.REQUESTED), capturedSearches.get(0).getRefundStatuses());
+	}
+	
+	@Test
+	public void doSearch_shouldNotSetRefundStatusesWhenParamMissing() {
+		RequestContext context = buildRefundContext(null);
+		
+		resource.doSearch(context);
+		
+		assertNull(capturedSearches.get(0).getRefundStatuses());
+	}
+	
+	@Test
+	public void doSearch_shouldParseCommaSeparatedRefundStatuses() {
+		RequestContext context = buildRefundContext("approved, rejected");
+		
+		resource.doSearch(context);
+		
+		assertEquals(Arrays.asList(RefundStatus.APPROVED, RefundStatus.REJECTED),
+		    capturedSearches.get(0).getRefundStatuses());
+	}
+	
+	@Test
+	public void doSearch_shouldRejectInvalidRefundStatus() {
+		RequestContext context = buildRefundContext("MAYBE");
+		
+		InvalidSearchException ex = assertThrows(InvalidSearchException.class, () -> resource.doSearch(context));
+		assertTrue(ex.getMessage().contains("MAYBE"));
+		assertTrue(ex.getMessage().contains("REQUESTED"));
 	}
 	
 	@Test
@@ -230,6 +286,36 @@ public class BillResourceTest {
 		resource.save(bill);
 		
 		assertNull(bill.getVisit());
+	}
+	
+	@Test
+	public void getActiveRefunds_shouldExcludeVoidedRefunds() {
+		Bill bill = new Bill();
+		bill.setRefunds(new HashSet<>(Arrays.asList(refundWithStatus(RefundStatus.REQUESTED, false),
+		    refundWithStatus(RefundStatus.APPROVED, false), refundWithStatus(RefundStatus.REQUESTED, true))));
+		
+		List<BillRefund> result = resource.getActiveRefunds(bill);
+		
+		assertEquals(2, result.size());
+		assertTrue(result.stream().noneMatch(r -> r.getVoided()));
+	}
+	
+	@Test
+	public void getActiveRefunds_shouldReturnEmptyWhenBillHasNoRefunds() {
+		Bill bill = new Bill();
+		
+		List<BillRefund> result = resource.getActiveRefunds(bill);
+		
+		assertEquals(0, result.size());
+	}
+	
+	@Test
+	public void getRepresentationDescription_shouldIncludeRefundsInDefaultAndFullRep() {
+		DelegatingResourceDescription defaultRep = resource.getRepresentationDescription(Representation.DEFAULT);
+		DelegatingResourceDescription fullRep = resource.getRepresentationDescription(Representation.FULL);
+		
+		assertTrue(defaultRep.getProperties().containsKey("refunds"), "DEFAULT representation must include refunds");
+		assertTrue(fullRep.getProperties().containsKey("refunds"), "FULL representation must include refunds");
 	}
 	
 	@Test

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
@@ -305,6 +305,8 @@ public class BillResourceTest {
 	
 	@Test
 	public void getActiveRefunds_shouldReturnEmptyWhenBillHasNoRefunds() {
+		contextMock.when(() -> Context.hasPrivilege(PrivilegeConstants.VIEW_REFUNDS)).thenReturn(true);
+		
 		Bill bill = new Bill();
 		
 		List<BillRefund> result = resource.getActiveRefunds(bill);

--- a/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/billing/web/rest/resource/BillResourceTest.java
@@ -47,6 +47,7 @@ import org.openmrs.module.billing.api.model.CashPoint;
 import org.openmrs.module.billing.api.model.DiscountStatus;
 import org.openmrs.module.billing.api.model.RefundStatus;
 import org.openmrs.module.billing.api.search.BillSearch;
+import org.openmrs.module.billing.api.util.PrivilegeConstants;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -290,6 +291,8 @@ public class BillResourceTest {
 	
 	@Test
 	public void getActiveRefunds_shouldExcludeVoidedRefunds() {
+		contextMock.when(() -> Context.hasPrivilege(PrivilegeConstants.VIEW_REFUNDS)).thenReturn(true);
+		
 		Bill bill = new Bill();
 		bill.setRefunds(new HashSet<>(Arrays.asList(refundWithStatus(RefundStatus.REQUESTED, false),
 		    refundWithStatus(RefundStatus.APPROVED, false), refundWithStatus(RefundStatus.REQUESTED, true))));


### PR DESCRIPTION
## Summary

- Adds a `refundStatus` query parameter to `GET /rest/v1/billing/bill` so callers can filter bills by the status of their associated refunds (e.g. `?refundStatus=REQUESTED` or `?refundStatus=REQUESTED,COMPLETED`)
- Validates that only known `RefundStatus` enum values are accepted; throws `InvalidSearchException` if the parameter is present but resolves to no valid values
- Exposes `refunds` in both the DEFAULT and FULL `BillResource` representations so clients receive refund data without needing a separate request

## Changes

- `BillResource`: parse and validate `refundStatus` param; add `refunds` to DEFAULT/FULL rep descriptions
- `HibernateBillDAOTest`: additional assertions covering bills with no refund rows and multi-status deduplication with voided refunds
- `BillRefundStatusFilterTest.xml`: new bill 2006 fixture (no refund rows) to verify the EXISTS predicate correctly excludes it
- `BillResourceTest`: representation description test asserting `refunds` is present in DEFAULT and FULL reps