### PR TITLE
Fix patient payment status returning PAID when no active bills exist

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolver.java
@@ -20,6 +20,7 @@ import org.openmrs.module.billing.api.model.PatientPaymentStatus;
 import org.openmrs.module.billing.api.model.PatientPaymentStatusResult;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class DefaultPatientPaymentStatusResolver implements PatientPaymentStatusResolver {
@@ -28,12 +29,22 @@ public class DefaultPatientPaymentStatusResolver implements PatientPaymentStatus
 	
 	static final String MSG_NO_OUTSTANDING = "billing.patientPaymentStatus.noOutstanding";
 	
+	static final String MSG_NO_BILLS = "billing.patientPaymentStatus.noBills";
+	
 	private final BillService billService;
 	
 	@Override
 	public PatientPaymentStatusResult resolve(Patient patient) {
 		List<Bill> bills = billService.getBillsByPatientUuid(patient.getUuid(), null);
-		boolean hasOutstanding = bills.stream().filter(b -> !Boolean.TRUE.equals(b.getVoided()))
+		List<Bill> activeBills = bills.stream().filter(b -> !Boolean.TRUE.equals(b.getVoided()))
+		        .collect(Collectors.toList());
+		
+		if (activeBills.isEmpty()) {
+			String reason = Context.getMessageSourceService().getMessage(MSG_NO_BILLS);
+			return PatientPaymentStatusResult.builder().status(PatientPaymentStatus.UNKNOWN).reason(reason).build();
+		}
+		
+		boolean hasOutstanding = activeBills.stream()
 		        .anyMatch(b -> b.getStatus() == BillStatus.PENDING || b.getStatus() == BillStatus.POSTED);
 		
 		String reason = Context.getMessageSourceService().getMessage(hasOutstanding ? MSG_OUTSTANDING : MSG_NO_OUTSTANDING);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -260,3 +260,4 @@ openhmis.cashier.report.error.selectReport=You must select a report.
 # Patient payment status
 billing.patientPaymentStatus.outstanding=Outstanding bill(s) present
 billing.patientPaymentStatus.noOutstanding=No outstanding bills
+billing.patientPaymentStatus.noBills=No bills on record

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/DefaultPatientPaymentStatusResolverTest.java
@@ -58,6 +58,8 @@ public class DefaultPatientPaymentStatusResolverTest {
 		        .thenReturn("Outstanding bill(s) present");
 		lenient().when(messageSourceService.getMessage(DefaultPatientPaymentStatusResolver.MSG_NO_OUTSTANDING))
 		        .thenReturn("No outstanding bills");
+		lenient().when(messageSourceService.getMessage(DefaultPatientPaymentStatusResolver.MSG_NO_BILLS))
+		        .thenReturn("No bills on record");
 		contextMock = mockStatic(Context.class);
 		contextMock.when(Context::getMessageSourceService).thenReturn(messageSourceService);
 		
@@ -74,13 +76,13 @@ public class DefaultPatientPaymentStatusResolverTest {
 	}
 	
 	@Test
-	public void resolve_shouldReturnPaidWhenPatientHasNoBills() {
+	public void resolve_shouldReturnUnknownWhenPatientHasNoBills() {
 		when(billService.getBillsByPatientUuid(PATIENT_UUID, null)).thenReturn(Collections.emptyList());
 		
 		PatientPaymentStatusResult result = resolver.resolve(patient);
 		
-		assertEquals(PatientPaymentStatus.PAID, result.getStatus());
-		assertEquals("No outstanding bills", result.getReason());
+		assertEquals(PatientPaymentStatus.UNKNOWN, result.getStatus());
+		assertEquals("No bills on record", result.getReason());
 	}
 	
 	@Test
@@ -120,11 +122,22 @@ public class DefaultPatientPaymentStatusResolverTest {
 	}
 	
 	@Test
-	public void resolve_shouldIgnoreVoidedPendingBills() {
+	public void resolve_shouldReturnUnknownWhenAllBillsAreVoided() {
 		when(billService.getBillsByPatientUuid(PATIENT_UUID, null))
 		        .thenReturn(Collections.singletonList(bill(BillStatus.PENDING, true)));
 		
-		assertEquals(PatientPaymentStatus.PAID, resolver.resolve(patient).getStatus());
+		PatientPaymentStatusResult result = resolver.resolve(patient);
+		
+		assertEquals(PatientPaymentStatus.UNKNOWN, result.getStatus());
+		assertEquals("No bills on record", result.getReason());
+	}
+	
+	@Test
+	public void resolve_shouldReturnUnknownWhenMultipleBillsAreAllVoided() {
+		when(billService.getBillsByPatientUuid(PATIENT_UUID, null)).thenReturn(
+		    Arrays.asList(bill(BillStatus.PENDING, true), bill(BillStatus.PAID, true), bill(BillStatus.POSTED, true)));
+		
+		assertEquals(PatientPaymentStatus.UNKNOWN, resolver.resolve(patient).getStatus());
 	}
 	
 	@Test


### PR DESCRIPTION
Patients with no bills used to return `PAID`, while this was technically the intended behaviour, it's confusing to see the `PAID` tag on a patient when they have no bills at all. This changes that to instead return unknown if a patient has no bills.
