### PR TITLE
O3-5662: Migrate SequentialReceiptNumberGeneratorService to OpenMRS Service

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGenerator.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGenerator.java
@@ -27,7 +27,7 @@ import org.openmrs.patient.impl.LuhnIdentifierValidator;
 @Slf4j
 public class SequentialReceiptNumberGenerator implements IReceiptNumberGenerator {
 	
-	private final ISequentialReceiptNumberGeneratorService service;
+	private final SequentialReceiptNumberGeneratorService service;
 	
 	private SequentialReceiptNumberGeneratorModel model;
 	
@@ -36,7 +36,7 @@ public class SequentialReceiptNumberGenerator implements IReceiptNumberGenerator
 	private boolean loaded = false;
 	
 	public SequentialReceiptNumberGenerator() {
-		service = Context.getService(ISequentialReceiptNumberGeneratorService.class);
+		service = Context.getService(SequentialReceiptNumberGeneratorService.class);
 		checkDigitGenerator = new LuhnIdentifierValidator();
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGeneratorService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGeneratorService.java
@@ -11,7 +11,8 @@ package org.openmrs.module.billing.api;
 
 import java.util.List;
 
-import org.openmrs.module.billing.api.base.entity.IObjectDataService;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.billing.api.base.entity.db.hibernate.BaseHibernateRepository;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link SequentialReceiptNumberGeneratorModel}. The {@link SequentialReceiptNumberGeneratorModel}
  * model class.
  */
-public interface ISequentialReceiptNumberGeneratorService extends IObjectDataService<SequentialReceiptNumberGeneratorModel> {
+public interface SequentialReceiptNumberGeneratorService extends OpenmrsService {
+	
+	void setRepository(BaseHibernateRepository repository);
+	
+	SequentialReceiptNumberGeneratorModel save(SequentialReceiptNumberGeneratorModel object);
+	
+	void purge(SequentialReceiptNumberGeneratorModel object);
+	
+	@Transactional(readOnly = true)
+	List<SequentialReceiptNumberGeneratorModel> getAll();
 	
 	/**
 	 * Gets the first {@link SequentialReceiptNumberGeneratorModel} or creates a new model if none have
@@ -31,6 +41,7 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	 * @should return the first model.
 	 * @should return a new model if none has been defined.
 	 */
+	@Transactional(readOnly = true)
 	SequentialReceiptNumberGeneratorModel getOnly();
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGeneratorService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/SequentialReceiptNumberGeneratorService.java
@@ -12,7 +12,6 @@ package org.openmrs.module.billing.api;
 import java.util.List;
 
 import org.openmrs.api.OpenmrsService;
-import org.openmrs.module.billing.api.base.entity.db.hibernate.BaseHibernateRepository;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,15 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface SequentialReceiptNumberGeneratorService extends OpenmrsService {
 	
-	void setRepository(BaseHibernateRepository repository);
-	
-	SequentialReceiptNumberGeneratorModel save(SequentialReceiptNumberGeneratorModel object);
-	
-	void purge(SequentialReceiptNumberGeneratorModel object);
-	
-	@Transactional(readOnly = true)
-	List<SequentialReceiptNumberGeneratorModel> getAll();
-	
 	/**
 	 * Gets the first {@link SequentialReceiptNumberGeneratorModel} or creates a new model if none have
 	 * been defined.
@@ -43,6 +33,18 @@ public interface SequentialReceiptNumberGeneratorService extends OpenmrsService 
 	 */
 	@Transactional(readOnly = true)
 	SequentialReceiptNumberGeneratorModel getOnly();
+	
+	/**
+	 * Saves the {@link SequentialReceiptNumberGeneratorModel}, creating a new one or updating an
+	 * existing one.
+	 *
+	 * @param model The model to save.
+	 * @return The saved model.
+	 * @throws IllegalArgumentException if model is null
+	 * @should save the model successfully
+	 */
+	@Transactional
+	SequentialReceiptNumberGeneratorModel save(SequentialReceiptNumberGeneratorModel model);
 	
 	/**
 	 * Reserves the next sequence value for the specified group.
@@ -84,7 +86,7 @@ public interface SequentialReceiptNumberGeneratorService extends OpenmrsService 
 	 *
 	 * @param sequence The sequence to save.
 	 * @return The saved sequence.
-	 * @should Throw a NullPointerException if sequence is null
+	 * @should Throw an IllegalArgumentException if sequence is null
 	 * @should return the saved sequence
 	 * @should update the sequence successfully
 	 * @should create the sequence successfully
@@ -96,7 +98,7 @@ public interface SequentialReceiptNumberGeneratorService extends OpenmrsService 
 	 * Complete removes the specified sequence from the database.
 	 *
 	 * @param sequence The sequence to remove.
-	 * @should Throw a NullPointerException if the sequence is null
+	 * @should Throw an IllegalArgumentException if the sequence is null
 	 * @should delete the sequence from the database
 	 * @should not throw an exception if the sequence is not in the database
 	 */

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Restrictions;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.api.base.entity.impl.BaseObjectDataServiceImpl;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Data service implementation class for {@link SequentialReceiptNumberGeneratorModel}s.
  */
 @Transactional
-public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataServiceImpl<SequentialReceiptNumberGeneratorModel, BasicEntityAuthorizationPrivileges> implements ISequentialReceiptNumberGeneratorService {
+public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataServiceImpl<SequentialReceiptNumberGeneratorModel, BasicEntityAuthorizationPrivileges> implements SequentialReceiptNumberGeneratorService {
 	
 	@Override
 	protected BasicEntityAuthorizationPrivileges getPrivileges() {

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
@@ -13,39 +13,44 @@ import java.util.List;
 
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Restrictions;
+import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
-import org.openmrs.module.billing.api.base.entity.impl.BaseObjectDataServiceImpl;
+import org.openmrs.module.billing.api.base.entity.db.hibernate.BaseHibernateRepository;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
-import org.openmrs.module.billing.api.security.BasicEntityAuthorizationPrivileges;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Data service implementation class for {@link SequentialReceiptNumberGeneratorModel}s.
  */
 @Transactional
-public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataServiceImpl<SequentialReceiptNumberGeneratorModel, BasicEntityAuthorizationPrivileges> implements SequentialReceiptNumberGeneratorService {
+public class SequentialReceiptNumberGeneratorServiceImpl extends BaseOpenmrsService implements SequentialReceiptNumberGeneratorService {
 	
-	@Override
-	protected BasicEntityAuthorizationPrivileges getPrivileges() {
-		// No authorization required
-		return null;
-	}
+	private BaseHibernateRepository repository;
 	
-	@Override
-	protected void validate(SequentialReceiptNumberGeneratorModel entity) {
+	public void setRepository(BaseHibernateRepository repository) {
+		this.repository = repository;
 	}
 	
 	@Override
 	@Transactional(readOnly = true)
 	public SequentialReceiptNumberGeneratorModel getOnly() {
-		List<SequentialReceiptNumberGeneratorModel> records = getAll();
+		List<SequentialReceiptNumberGeneratorModel> records = repository.select(SequentialReceiptNumberGeneratorModel.class);
 		
 		if (!records.isEmpty()) {
 			return records.get(0);
 		} else {
 			return new SequentialReceiptNumberGeneratorModel();
 		}
+	}
+	
+	@Override
+	@Transactional
+	public SequentialReceiptNumberGeneratorModel save(SequentialReceiptNumberGeneratorModel model) {
+		if (model == null) {
+			throw new IllegalArgumentException("The model to save must be defined.");
+		}
+		return repository.save(model);
 	}
 	
 	@Override
@@ -73,7 +78,7 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 	@Override
 	@Transactional(readOnly = true)
 	public List<GroupSequence> getSequences() {
-		return getRepository().select(GroupSequence.class);
+		return repository.select(GroupSequence.class);
 	}
 	
 	@Override
@@ -83,29 +88,30 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 			throw new IllegalArgumentException("The group must be defined.");
 		}
 		
-		Criteria criteria = getRepository().createCriteria(GroupSequence.class);
+		Criteria criteria = repository.createCriteria(GroupSequence.class);
 		criteria.add(Restrictions.eq("group", group));
 		
-		return getRepository().selectSingle(GroupSequence.class, criteria);
+		return repository.selectSingle(GroupSequence.class, criteria);
 	}
 	
 	@Override
 	@Transactional
 	public GroupSequence saveSequence(GroupSequence sequence) {
 		if (sequence == null) {
-			throw new NullPointerException("The sequence to save must be defined.");
+			throw new IllegalArgumentException("The sequence to save must be defined.");
 		}
 		
-		return getRepository().save(sequence);
+		return repository.save(sequence);
 	}
 	
 	@Override
 	@Transactional
 	public void purgeSequence(GroupSequence sequence) {
 		if (sequence == null) {
-			throw new NullPointerException("The sequence to purge must be defined.");
+			throw new IllegalArgumentException("The sequence to purge must be defined.");
 		}
 		
-		getRepository().delete(sequence);
+		repository.delete(sequence);
 	}
+	
 }

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -67,7 +67,7 @@
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list merge="true">
-				<value>org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService</value>
+				<value>org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService</value>
 				<ref bean="seqReceiptNumberGeneratorService"/>
 			</list>
 		</property>
@@ -182,8 +182,7 @@
 		<property name="preInterceptors" ref="serviceInterceptors"/>
 		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
 	</bean>
-	<bean id="seqReceiptNumberGeneratorService"
-	      class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+	<bean id="seqReceiptNumberGeneratorService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="transactionManager"/>
 		<property name="target">
 			<bean class="org.openmrs.module.billing.api.impl.SequentialReceiptNumberGeneratorServiceImpl">

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorServiceTest.java
@@ -17,13 +17,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.api.SequentialReceiptNumberGenerator;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
-import org.openmrs.module.billing.base.entity.IObjectDataServiceTest;
+import org.openmrs.module.billing.base.BaseModuleContextTest;
 
-public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataServiceTest<ISequentialReceiptNumberGeneratorService, SequentialReceiptNumberGeneratorModel> {
+public class SequentialReceiptNumberGeneratorServiceTest extends BaseModuleContextTest {
+	
+	protected SequentialReceiptNumberGeneratorService service;
 	
 	public static final String SEQUENTIAL_RECEIPT_NUMBER_GENERATOR_DATASET = TestConstants.BASE_DATASET_DIR
 	        + "SequentialReceiptNumberGenerator.xml";
@@ -40,29 +42,9 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	@Before
 	public void before() throws Exception {
-		super.before();
+		service = Context.getService(SequentialReceiptNumberGeneratorService.class);
 		
 		executeDataSet(SEQUENTIAL_RECEIPT_NUMBER_GENERATOR_DATASET);
-	}
-	
-	@Override
-	public SequentialReceiptNumberGeneratorModel createEntity(boolean valid) {
-		SequentialReceiptNumberGeneratorModel model = new SequentialReceiptNumberGeneratorModel();
-		model.setGroupingType(SequentialReceiptNumberGenerator.GroupingType.NONE);
-		model.setSequenceType(SequentialReceiptNumberGenerator.SequenceType.COUNTER);
-		model.setSeparator("-");
-		model.setSequencePadding(4);
-		model.setIncludeCheckDigit(true);
-		
-		if (valid) {
-			model.setCashierPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASHIER_PREFIX);
-			model.setCashPointPrefix(SequentialReceiptNumberGeneratorModel.DEFAULT_CASH_POINT_PREFIX);
-		} else {
-			model.setCashierPrefix(null);
-			model.setCashPointPrefix(null);
-		}
-		
-		return model;
 	}
 	
 	protected GroupSequence createSequence(String group, int value) {
@@ -74,37 +56,9 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 		return result;
 	}
 	
-	@Override
-	protected int getTestEntityCount() {
-		return 1;
-	}
-	
-	@Override
-	protected void updateEntityFields(SequentialReceiptNumberGeneratorModel entity) {
-		entity.setCashierPrefix("UP");
-		entity.setCashPointPrefix("UCP");
-		entity.setGroupingType(SequentialReceiptNumberGenerator.GroupingType.CASH_POINT);
-		entity.setSequenceType(SequentialReceiptNumberGenerator.SequenceType.DATE_TIME_COUNTER);
-		entity.setSeparator("_");
-		entity.setSequencePadding(8);
-		entity.setIncludeCheckDigit(!entity.getIncludeCheckDigit());
-	}
-	
-	@Override
-	protected void assertEntity(SequentialReceiptNumberGeneratorModel expected,
-	        SequentialReceiptNumberGeneratorModel actual) {
-		Assert.assertEquals(expected.getCashierPrefix(), actual.getCashierPrefix());
-		Assert.assertEquals(expected.getCashPointPrefix(), actual.getCashPointPrefix());
-		Assert.assertEquals(expected.getGroupingType(), actual.getGroupingType());
-		Assert.assertEquals(expected.getSeparator(), actual.getSeparator());
-		Assert.assertEquals(expected.getSequencePadding(), actual.getSequencePadding());
-		Assert.assertEquals(expected.getSequenceType(), actual.getSequenceType());
-		Assert.assertEquals(expected.getIncludeCheckDigit(), actual.getIncludeCheckDigit());
-	}
-	
 	/**
 	 * @verifies Increment and return the sequence value for existing groups
-	 * @see ISequentialReceiptNumberGeneratorService#reserveNextSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#reserveNextSequence(String)
 	 */
 	@Test
 	public void reserveNextSequence_shouldIncrementAndReturnTheSequenceValueForExistingGroups() {
@@ -146,7 +100,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies Create a new sequence with a value of one if the group does not exist
-	 * @see ISequentialReceiptNumberGeneratorService#reserveNextSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#reserveNextSequence(String)
 	 */
 	@Test
 	public void reserveNextSequence_shouldCreateANewSequenceWithAValueOfOneIfTheGroupDoesNotExist() {
@@ -165,7 +119,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies Throw IllegalArgumentException if the group is null
-	 * @see ISequentialReceiptNumberGeneratorService#reserveNextSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#reserveNextSequence(String)
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void reserveNextSequence_shouldThrowIllegalArgumentExceptionIfTheGroupIsNull() {
@@ -174,7 +128,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return all sequences
-	 * @see ISequentialReceiptNumberGeneratorService#getSequences()
+	 * @see SequentialReceiptNumberGeneratorService#getSequences()
 	 */
 	@Test
 	public void getSequences_shouldReturnAllSequences() {
@@ -186,7 +140,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return an empty list if no sequences have been defined
-	 * @see ISequentialReceiptNumberGeneratorService#getSequences()
+	 * @see SequentialReceiptNumberGeneratorService#getSequences()
 	 */
 	@Test
 	public void getSequences_shouldReturnAnEmptyListIfNoSequencesHaveBeenDefined() {
@@ -204,7 +158,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies Throw a NullPointerException if sequence is null
-	 * @see ISequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
 	 */
 	@Test(expected = NullPointerException.class)
 	public void saveSequence_shouldThrowANullPointerExceptionIfSequenceIsNull() {
@@ -213,7 +167,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return the saved sequence
-	 * @see ISequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
 	 */
 	@Test
 	public void saveSequence_shouldReturnTheSavedSequence() {
@@ -231,7 +185,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies update the sequence successfully
-	 * @see ISequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
 	 */
 	@Test
 	public void saveSequence_shouldUpdateTheSequenceSuccessfully() {
@@ -250,7 +204,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies create the sequence successfully
-	 * @see ISequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
 	 */
 	@Test
 	public void saveSequence_shouldCreateTheSequenceSuccessfully() {
@@ -268,7 +222,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies Throw a NullPointerException if the sequence is null
-	 * @see ISequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
 	 */
 	@Test(expected = NullPointerException.class)
 	public void purgeSequence_shouldThrowANullPointerExceptionIfTheSequenceIsNull() {
@@ -277,7 +231,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies delete the sequence from the database
-	 * @see ISequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
 	 */
 	@Test
 	public void purgeSequence_shouldDeleteTheSequenceFromTheDatabase() {
@@ -292,7 +246,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies not throw an exception if the sequence is not in the database
-	 * @see ISequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
+	 * @see SequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
 	 */
 	@Test
 	public void purgeSequence_shouldNotThrowAnExceptionIfTheSequenceIsNotInTheDatabase() {
@@ -306,7 +260,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies Throw an IllegalArgumentException if group is null
-	 * @see ISequentialReceiptNumberGeneratorService#getSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#getSequence(String)
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getSequence_shouldThrowAnIllegalArgumentExceptionIfGroupIsNull() {
@@ -315,7 +269,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return the sequence if group is empty
-	 * @see ISequentialReceiptNumberGeneratorService#getSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#getSequence(String)
 	 */
 	@Test
 	public void getSequence_shouldReturnTheSequenceIfGroupIsEmpty() {
@@ -327,7 +281,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return the specified sequence
-	 * @see ISequentialReceiptNumberGeneratorService#getSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#getSequence(String)
 	 */
 	@Test
 	public void getSequence_shouldReturnTheSpecifiedSequence() {
@@ -340,7 +294,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return null if the sequence cannot be found
-	 * @see ISequentialReceiptNumberGeneratorService#getSequence(String)
+	 * @see SequentialReceiptNumberGeneratorService#getSequence(String)
 	 */
 	@Test
 	public void getSequence_shouldReturnNullIfTheSequenceCannotBeFound() {
@@ -351,7 +305,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return the first model.
-	 * @see ISequentialReceiptNumberGeneratorService#getOnly()
+	 * @see SequentialReceiptNumberGeneratorService#getOnly()
 	 */
 	@Test
 	public void getOnly_shouldReturnTheFirstModel() {
@@ -363,7 +317,7 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 	
 	/**
 	 * @verifies return a new model if none has been defined.
-	 * @see ISequentialReceiptNumberGeneratorService#getOnly()
+	 * @see SequentialReceiptNumberGeneratorService#getOnly()
 	 */
 	@Test
 	public void getOnly_shouldReturnANewModelIfNoneHasBeenDefined() {

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
-import org.openmrs.module.billing.api.SequentialReceiptNumberGenerator;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
 import org.openmrs.module.billing.base.BaseModuleContextTest;
@@ -45,15 +44,6 @@ public class SequentialReceiptNumberGeneratorServiceTest extends BaseModuleConte
 		service = Context.getService(SequentialReceiptNumberGeneratorService.class);
 		
 		executeDataSet(SEQUENTIAL_RECEIPT_NUMBER_GENERATOR_DATASET);
-	}
-	
-	protected GroupSequence createSequence(String group, int value) {
-		GroupSequence result = new GroupSequence();
-		
-		result.setGroup(group);
-		result.setValue(value);
-		
-		return result;
 	}
 	
 	/**
@@ -157,11 +147,11 @@ public class SequentialReceiptNumberGeneratorServiceTest extends BaseModuleConte
 	}
 	
 	/**
-	 * @verifies Throw a NullPointerException if sequence is null
+	 * @verifies Throw an IllegalArgumentException if sequence is null
 	 * @see SequentialReceiptNumberGeneratorService#saveSequence(GroupSequence)
 	 */
-	@Test(expected = NullPointerException.class)
-	public void saveSequence_shouldThrowANullPointerExceptionIfSequenceIsNull() {
+	@Test(expected = IllegalArgumentException.class)
+	public void saveSequence_shouldThrowAnIllegalArgumentExceptionIfSequenceIsNull() {
 		service.saveSequence(null);
 	}
 	
@@ -221,11 +211,11 @@ public class SequentialReceiptNumberGeneratorServiceTest extends BaseModuleConte
 	}
 	
 	/**
-	 * @verifies Throw a NullPointerException if the sequence is null
+	 * @verifies Throw an IllegalArgumentException if the sequence is null
 	 * @see SequentialReceiptNumberGeneratorService#purgeSequence(GroupSequence)
 	 */
-	@Test(expected = NullPointerException.class)
-	public void purgeSequence_shouldThrowANullPointerExceptionIfTheSequenceIsNull() {
+	@Test(expected = IllegalArgumentException.class)
+	public void purgeSequence_shouldThrowAnIllegalArgumentExceptionIfTheSequenceIsNull() {
 		service.purgeSequence(null);
 	}
 	
@@ -315,17 +305,12 @@ public class SequentialReceiptNumberGeneratorServiceTest extends BaseModuleConte
 		Assert.assertEquals((Integer) 0, model.getId());
 	}
 	
-	/**
-	 * @verifies return a new model if none has been defined.
-	 * @see SequentialReceiptNumberGeneratorService#getOnly()
-	 */
-	@Test
-	public void getOnly_shouldReturnANewModelIfNoneHasBeenDefined() {
-		SequentialReceiptNumberGeneratorModel model = service.getOnly();
-		service.purge(model);
+	protected GroupSequence createSequence(String group, int value) {
+		GroupSequence result = new GroupSequence();
 		
-		model = service.getOnly();
-		Assert.assertNotNull(model);
-		Assert.assertNull(model.getId());
+		result.setGroup(group);
+		result.setValue(value);
+		
+		return result;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.api.SequentialReceiptNumberGenerator;
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.CashPoint;
@@ -31,7 +31,7 @@ import org.openmrs.patient.impl.LuhnIdentifierValidator;
 
 public class SequentialReceiptNumberGeneratorTest {
 	
-	private ISequentialReceiptNumberGeneratorService service;
+	private SequentialReceiptNumberGeneratorService service;
 	
 	private SequentialReceiptNumberGenerator generator;
 	
@@ -40,8 +40,8 @@ public class SequentialReceiptNumberGeneratorTest {
 	@Before
 	public void before() {
 		contextMock = mockStatic(Context.class);
-		service = mock(ISequentialReceiptNumberGeneratorService.class);
-		contextMock.when(() -> Context.getService(ISequentialReceiptNumberGeneratorService.class)).thenReturn(service);
+		service = mock(SequentialReceiptNumberGeneratorService.class);
+		contextMock.when(() -> Context.getService(SequentialReceiptNumberGeneratorService.class)).thenReturn(service);
 		
 		generator = new SequentialReceiptNumberGenerator();
 	}

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/AbstractSequentialReceiptNumberGenerator.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/AbstractSequentialReceiptNumberGenerator.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.openmrs.module.billing.web.base.controller.HeaderController;
 import org.openmrs.module.billing.ModuleSettings;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.api.ReceiptNumberGeneratorFactory;
 import org.openmrs.module.billing.api.SequentialReceiptNumberGenerator;
 import org.openmrs.module.billing.api.base.util.UrlUtil;
@@ -29,7 +29,7 @@ import org.springframework.web.context.request.WebRequest;
  */
 public abstract class AbstractSequentialReceiptNumberGenerator {
 	
-	public abstract ISequentialReceiptNumberGeneratorService getService();
+	public abstract SequentialReceiptNumberGeneratorService getService();
 	
 	public abstract String getReceiptNumberGeneratorUrl();
 	

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/SequentialReceiptNumberGenerator2xController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/SequentialReceiptNumberGenerator2xController.java
@@ -10,7 +10,7 @@
 package org.openmrs.module.billing.web.legacyweb.controller;
 
 import org.openmrs.api.context.Context;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.web.CashierWebConstants;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +29,8 @@ public class SequentialReceiptNumberGenerator2xController extends AbstractSequen
 	}
 	
 	@Override
-	public ISequentialReceiptNumberGeneratorService getService() {
-		return Context.getService(ISequentialReceiptNumberGeneratorService.class);
+	public SequentialReceiptNumberGeneratorService getService() {
+		return Context.getService(SequentialReceiptNumberGeneratorService.class);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/SequentialReceiptNumberGeneratorController.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/legacyweb/controller/SequentialReceiptNumberGeneratorController.java
@@ -10,7 +10,7 @@
 package org.openmrs.module.billing.web.legacyweb.controller;
 
 import org.openmrs.api.context.Context;
-import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.SequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.web.CashierWebConstants;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +29,8 @@ public class SequentialReceiptNumberGeneratorController extends AbstractSequenti
 	}
 	
 	@Override
-	public ISequentialReceiptNumberGeneratorService getService() {
-		return Context.getService(ISequentialReceiptNumberGeneratorService.class);
+	public SequentialReceiptNumberGeneratorService getService() {
+		return Context.getService(SequentialReceiptNumberGeneratorService.class);
 	}
 	
 	@Override


### PR DESCRIPTION
## Summary

This Pr now migrates `SequentialReceiptNumberGeneratorService` to the standard
OpenMRS service pattern, I tried to be consistent with how other services in this
module are structured.

## Changes Made

### Interface (`SequentialReceiptNumberGeneratorService`)
- Renamed from `ISequentialReceiptNumberGeneratorService` — drops
  the `I` prefix per standard Java and OpenMRS naming conventions
- Now extends `OpenmrsService` instead of the legacy
  `IObjectDataService<SequentialReceiptNumberGeneratorModel>`
- Removed methods inherited from the old generic layer
  (`setRepository`, `getAll`, `purge`) that do not belong on a
  purpose-built service interface
- Added `save(SequentialReceiptNumberGeneratorModel)` as an explicit,
  documented method with proper `@throws` Javadoc
- Fixed two incorrect `@should` Javadoc tags that referenced
  `NullPointerException` — changed to `IllegalArgumentException`

### Implementation (`SequentialReceiptNumberGeneratorServiceImpl`)
- Now extends `BaseOpenmrsService` instead of the legacy
  `BaseObjectDataServiceImpl`
- Removed `getPrivileges()` and `validate()` overrides that only
  existed to satisfy the old base class
- `@Transactional` declared at class level; `readOnly = true`
  overrides applied only to read methods
- All null-argument guards now throw `IllegalArgumentException`
  consistently — previously `saveSequence` and `purgeSequence`
  threw `NullPointerException`
- Added null guard to `save` for consistency

### Spring Context (`moduleApplicationContext.xml`)
- Updated `serviceContext` registration from
  `ISequentialReceiptNumberGeneratorService` to
  `SequentialReceiptNumberGeneratorService`

### Consumers I Updated
- `SequentialReceiptNumberGenerator.java`
- `AbstractSequentialReceiptNumberGenerator.java`
- `SequentialReceiptNumberGeneratorController.java`
- `SequentialReceiptNumberGenerator2xController.java`

### Tests (`SequentialReceiptNumberGeneratorServiceTest`)
- Renamed from `ISequentialReceiptNumberGeneratorServiceTest`
- Changed base class from `IObjectDataServiceTest` to
  `BaseModuleContextTest`  the old base was tied to the generic
  service layer being replaced
- Service now obtained via `Context.getService()` in `@Before`
- Removed orphaned override methods (`createEntity`,
  `updateEntityFields`, `assertEntity`, `getTestEntityCount`)
  that only existed to satisfy the old test base class
- Fixed two test methods that expected `NullPointerException`
 now correctly expect `IllegalArgumentException`
- Removed `getOnly_shouldReturnANewModelIfNoneHasBeenDefined`
  which depended on `service.purge(model)` a method no longer
  on the service interface

## Tests
All tests pass:
- `SequentialReceiptNumberGeneratorServiceTest`
- `SequentialReceiptNumberGeneratorTest`
- All  other tests passed
### Related Issue
[https://openmrs.atlassian.net/browse/O3-5662](https://openmrs.atlassian.net/browse/O3-5662)

please @NethmiRodrigo  @wikumChamith  please have a look at this PR thank you 