### PR TITLE
Index billing records in the QueryStore for chart search (optional 2.9 integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ Provides REST API endpoints at `/rest/v1/billing/*` for bills, payments, payment
 
 Exposes bills as FHIR `Invoice` resources via the `fhir` submodule, built against the `fhir2` module. Supports OpenMRS Platform 2.5, 2.6, and 2.7 FHIR variants.
 
+### QueryStore / Chart Search Integration
+
+Projects billing records into the [OpenMRS QueryStore](https://github.com/openmrs/openmrs-module-querystore) so a clinician-facing semantic / keyword chart search (e.g. `chartsearchai`) can retrieve them. Three patient-scoped resource types are contributed through QueryStore's `ResourceTypeProvider` SPI:
+
+- **`billing_bill`** — one document per bill; its searchable text folds in the billed services / drugs / tests (line items), totals, amount paid, outstanding balance, payment status and cash point.
+- **`billing_discount`** — fee waivers / discounts (often a signal of a subsidized programme or financial hardship).
+- **`billing_refund`** — refunds.
+
+Steady-state indexing is event-driven and needs **no** changes to the base billing services: QueryStore's events-first consumer projects any entity for which a serializer is registered, using the `*ServiceEvent`s that core [openmrs-core#6084](https://github.com/openmrs/openmrs-core/pull/6084) publishes for `save*` / `void*` / `purge*` service methods — which billing's `saveBill` / `voidBill` / `purgeBill` (and `saveBillDiscount` / `saveBillRefund`) already are. Backfill of pre-existing records is admin-triggered via QueryStore's reindex endpoint (`POST /ws/rest/v1/querystore/reindex {"scope":"all"}`) or `BootstrapService`.
+
+Because QueryStore and the core `*ServiceEvent` API require **OpenMRS Platform 2.9** plus its Elasticsearch / Lucene backend, this integration is packaged as a **separate, optional `billing-querystore` omod** and is **not** part of the default build — the base billing module is unaffected and still targets 2.7.8. Build it explicitly and install the resulting `querystore/target/billing-querystore-*.omod` alongside billing only on servers that run QueryStore:
+
+```bash
+mvn -Pquerystore clean install
+```
+
+> **Runtime note:** the QueryStore SPI documents that whether a *module's* services emit the core `*ServiceEvent`s is deployment-dependent and should be verified on a live 2.9 server. If bills backfill but do not live-update, billing's services can publish the events themselves via a small aspect added to this submodule; backfill works regardless.
+
 ## Requirements
 
 - **OpenMRS Platform**: 2.7.8 (built and tested against; module `require_version` follows the build property)
@@ -69,6 +87,7 @@ Exposes bills as FHIR `Invoice` resources via the `fhir` submodule, built agains
   - Stock Management Module 1.4.0+
 - **Optional Modules**:
   - FHIR2 Module 2.4.0+ (required to use the FHIR Invoice submodule)
+  - QueryStore Module 1.0.0+ on Platform 2.9+ (required to use the optional `billing-querystore` chart-search integration)
   - IDGen Module 2.8+ (for custom receipt number generation)
   - UI Framework Module
   - App Framework Module

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Because QueryStore and the core `*ServiceEvent` API require **OpenMRS Platform 2
 mvn -Pquerystore clean install
 ```
 
-> **Runtime note:** the QueryStore SPI documents that whether a *module's* services emit the core `*ServiceEvent`s is deployment-dependent and should be verified on a live 2.9 server. If bills backfill but do not live-update, billing's services can publish the events themselves via a small aspect added to this submodule; backfill works regardless.
+Live sync uses two core event paths: `billing_bill` rides core #6084's AOP `*ServiceEvent`s (its `BillService` is an `OpenmrsService`), while `billing_discount` / `billing_refund` — whose services are plain interfaces — are projected by a `SaveDbEvent` listener over core's non-AOP Hibernate interceptor. All three also backfill via QueryStore's `reindex`. Verified end-to-end on a 2.9 + QueryStore + chartsearchai standalone.
+
+> The design decisions behind this integration (SPI vs. events, the optional-omod packaging, the two sync paths, indexed-type scope) are recorded in [docs/adr.md](docs/adr.md).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Exposes bills as FHIR `Invoice` resources via the `fhir` submodule, built agains
 
 Projects billing records into the [OpenMRS QueryStore](https://github.com/openmrs/openmrs-module-querystore) so a clinician-facing semantic / keyword chart search (e.g. `chartsearchai`) can retrieve them. Three patient-scoped resource types are contributed through QueryStore's `ResourceTypeProvider` SPI:
 
-- **`billing_bill`** — one document per bill; its searchable text folds in the billed services / drugs / tests (line items), totals, amount paid, outstanding balance, payment status and cash point.
+- **`billing_bill`** — one document per bill; its searchable text folds in the billed services / drugs / tests (line items), the raw total, amount paid, payment status and cash point. (Discount-adjusted figures are intentionally left to `billing_discount`, since approving a discount does not re-save the bill and a folded balance would go stale.)
 - **`billing_discount`** — fee waivers / discounts (often a signal of a subsidized programme or financial hardship).
 - **`billing_refund`** — refunds.
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -144,6 +144,25 @@ Excluded, with reasons:
 - Fewer types to serialize and keep in sync; the excluded config/metadata would add noise and mostly
   isn't projectable anyway.
 
+### Example chart-search queries
+Natural-language questions a clinician asks chart search (`POST /ws/rest/v1/chartsearchai/search`
+with `{"question": ..., "patient": ...}`), and the resource each is expected to surface. The
+*italicized* ones were exercised during verification (see the PR's verification comments) and
+returned the corresponding `resourceType`.
+
+- **`billing_bill`** — *"What has this patient been billed for, and what is the outstanding
+  balance?"*; "Does this patient have any unpaid bills?"; "Was the patient charged for a malaria
+  test / X-ray / consultation?"
+- **`billing_discount`** — *"Does this patient have any billing discounts or fee waivers, and for
+  how much?"*; "Is there a hardship or subsidized-programme waiver on this patient's bills?"
+- **`billing_refund`** — *"Has this patient had any bill refunds? What amount and reason?"*; "Was any
+  charge reversed or refunded for this patient?"
+
+Retrieval is semantic, not keyword-exact, so phrasing varies freely — "money owed", "charges",
+"waiver", "reimbursement" route to the right documents without matching the stored text verbatim.
+(A single question may cite more than one type — e.g. a refund question surfaced both
+`billing_refund` and the parent `billing_bill`, whose status had flipped to REFUND_REQUESTED.)
+
 ---
 
 ## Decision 4: billing_bill folds only fields that stay fresh on a bill save

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1,0 +1,214 @@
+# Architecture Decision Records
+
+This document captures the key architectural decisions for the OpenMRS Billing module. The first
+set records the **QueryStore / chart-search integration** (the optional `billing-querystore` omod,
+[PR #186](https://github.com/openmrs/openmrs-module-billing/pull/186)), which lets a clinician-facing
+semantic/keyword chart search (e.g. [chartsearchai](https://github.com/openmrs/openmrs-module-chartsearchai))
+retrieve a patient's bills.
+
+## Background
+
+The [OpenMRS QueryStore module](https://github.com/openmrs/openmrs-module-querystore) maintains a
+read-optimized projection of clinical data for semantic / free-text / kNN search, and exposes a
+`ResourceTypeProvider` SPI (its own [ADR Decision 13](https://github.com/openmrs/openmrs-module-querystore/blob/main/docs/adr.md))
+for modules to contribute custom resource types. This integration makes the Billing module such a
+provider so that bills, discounts, and refunds become searchable alongside core clinical data.
+
+## Conventions
+
+- Decisions are numbered and append-only once accepted; a superseded decision is marked and points
+  at its replacement rather than being edited away.
+- These decisions concern the integration only. The base Billing module (api/omod/fhir) is
+  intentionally left unchanged by them — see Decision 2.
+
+## Table of Contents
+
+1. [Integrate through the QueryStore ResourceTypeProvider SPI](#decision-1-integrate-through-the-querystore-resourcetypeprovider-spi)
+2. [Ship as a separate, optional, profile-gated omod](#decision-2-ship-as-a-separate-optional-profile-gated-omod)
+3. [Which billing records to index, and at what granularity](#decision-3-which-billing-records-to-index-and-at-what-granularity)
+4. [billing_bill folds only fields that stay fresh on a bill save](#decision-4-billing_bill-folds-only-fields-that-stay-fresh-on-a-bill-save)
+5. [Two sync paths: AOP service events for bills, Hibernate DB events for discounts and refunds](#decision-5-two-sync-paths-aop-service-events-for-bills-hibernate-db-events-for-discounts-and-refunds)
+6. [Require exact (SNAPSHOT) dependency versions](#decision-6-require-exact-snapshot-dependency-versions)
+
+---
+
+## Decision 1: Integrate through the QueryStore ResourceTypeProvider SPI
+
+### Status
+Accepted
+
+### Context
+chart-search needs billing records available in the query store. QueryStore is "events-first": its
+`CoreServiceEventListener` projects any entity for which a `ClinicalRecordSerializer` is registered,
+and it offers a `ResourceTypeProvider` SPI (serializer + optional bootstrapper) discovered via
+`Context.getRegisteredComponents(...)`. Its SPI walkthrough even uses `billing_bill` as the running
+example.
+
+### Decision
+Implement the integration purely as SPI contributions — per resource type a
+`ClinicalRecordSerializer` (mapping the entity to a `QueryDocument`), a `HibernateTypeBootstrapper`
+(one-time backfill of existing rows), and a `ResourceTypeProvider` bundling them — registered as
+Spring beans in the submodule's `moduleApplicationContext.xml`. We do **not** build a bespoke
+event/publish mechanism; steady-state indexing rides on the events QueryStore already consumes
+(see Decision 5), and initial backfill is admin-triggered via QueryStore's `reindex` endpoint.
+
+### Consequences
+- Minimal, declarative integration; QueryStore owns the store, embedding, schema lifecycle, search,
+  and authorization.
+- The module compiles against `querystore-api` (provided scope) and couples to its SPI contract.
+- "Register a serializer" — not "publish events" — is the mental model for maintainers.
+
+---
+
+## Decision 2: Ship as a separate, optional, profile-gated omod
+
+### Status
+Accepted
+
+### Context
+QueryStore and the core `*ServiceEvent` API it relies on require the OpenMRS platform **2.9** (and,
+in practice, an Elasticsearch/Lucene backend plus the querystore module), whereas the base Billing
+module targets **2.7.8** and is widely deployed on older platforms. The integration must not force
+every Billing deployment onto that stack.
+
+### Decision
+Put the integration in a new `querystore/` Maven module that builds its own `billing-querystore`
+omod, hard-requiring `billing` + `querystore` + platform 2.9. It is **not** in the default
+`<modules>`; it builds only under a `querystore` Maven profile (`mvn -Pquerystore`). The base
+`billing.omod` and the default build are unchanged.
+
+### Alternatives considered
+- **Bundle the SPI beans into the existing `omod`.** Rejected: with `provided`-scope `querystore-api`
+  the beans fail to instantiate when querystore is absent, and hard-requiring querystore would push
+  every Billing install onto platform 2.9 + Elasticsearch.
+- **A standalone repository.** Rejected: the code is billing-domain-specific (it serializes Bill /
+  BillDiscount / BillRefund), so it belongs with the module; a separate repo adds release/version
+  coordination for no benefit.
+
+### Consequences
+- Deployers running QueryStore drop in one extra omod; everyone else is unaffected.
+- The reactor produces two omods; the `querystore` profile compiles against 2.9 / querystore
+  SNAPSHOTs (see Decision 6) without disturbing the 2.7.8 default build.
+
+---
+
+## Decision 3: Which billing records to index, and at what granularity
+
+### Status
+Accepted
+
+### Context
+The goal is "what would help a clinician reading the patient chart," not a full financial export.
+The billing domain has many persistent types, but only some are patient-anchored and clinically
+useful, and QueryStore only projects `OpenmrsData` (not metadata).
+
+### Decision
+Index three patient-scoped resource types: **`billing_bill`**, **`billing_discount`**, and
+**`billing_refund`**.
+- `Bill` line items and payments are **folded into** `billing_bill` (they cascade with the bill and
+  have no independent lifecycle) — the searchable text leads with the billed services/drugs/tests.
+- Discounts and refunds are indexed as their **own** types (their lifecycles — waiver approval,
+  refund request/approval/completion — are patient-relevant in their own right).
+- Excluded: cash points, payment modes, the billable-service catalog, item prices, exemption
+  *rules*, timesheets, and sequence/infra models — facility config/ops or not patient-scoped (and,
+  being `OpenmrsMetadata` in several cases, not projectable by QueryStore anyway).
+
+### Consequences
+- High signal-to-noise for chart search: a clinician can find what a patient was charged for, and
+  whether an unpaid balance or a fee waiver exists.
+- Fewer types to serialize and keep in sync.
+
+---
+
+## Decision 4: billing_bill folds only fields that stay fresh on a bill save
+
+### Status
+Accepted
+
+### Context
+QueryStore re-projects `billing_bill` when a bill is (re)saved. A folded field is only kept current
+if every mutation that changes it re-saves the bill. `BillDiscountService.saveBillDiscount` persists
+the discount alone and does **not** re-save the parent bill, so a denormalized "amount after
+discount" / outstanding balance on `billing_bill` would silently overstate what the patient owes
+until the bill's next save.
+
+### Decision
+`billing_bill` exposes only bill-aggregate-derived fields that are refreshed on every `saveBill`:
+the raw (pre-discount) line-item **total**, **amount paid**, **status**, cash point, visit, and the
+billed-service list. It does **not** denormalize a discount-adjusted total or balance; discount
+detail lives on `billing_discount`. Consumers derive "outstanding" from total + amount paid.
+
+### Consequences
+- No silently-wrong financial figure in the index.
+- Confirmed in live testing: the LLM correctly answered "outstanding balance 500.00" from the emitted
+  `Total: 500, paid: 0` text.
+- Residual, documented eventual-consistency: line-item voids via the dedicated `voidBillLineItem`
+  endpoint lag until the bill's next save.
+
+---
+
+## Decision 5: Two sync paths: AOP service events for bills, Hibernate DB events for discounts and refunds
+
+### Status
+Accepted
+
+### Context
+openmrs-core #6084 (2.9) publishes change events at two layers: (a) an **AOP** advice
+(`OpenmrsServiceEventAdvice`, pointcut `target(org.openmrs.api.OpenmrsService)`) emits
+`SaveServiceEvent`/`VoidServiceEvent`/… for `OpenmrsService` `save*`/`void*`/… calls; (b) a
+**non-AOP** Hibernate interceptor (`EventInterceptor`) emits `SaveDbEvent`/`DeleteDbEvent` for
+*every* persisted entity, in-transaction on the flush thread. QueryStore's consumer subscribes to
+the AOP service events. `BillService extends OpenmrsService`, but `BillDiscountService` and
+`BillRefundService` are plain interfaces — so the AOP advice never fires for `saveBillDiscount`/
+`saveBillRefund`, and those types would live-sync from nothing.
+
+### Decision
+- `billing_bill`: rely on the AOP `*ServiceEvent`s QueryStore already consumes (no code — `saveBill`
+  qualifies).
+- `billing_discount` / `billing_refund`: add a `BillChildDbEventListener` in the submodule that
+  consumes core's **non-AOP** `SaveDbEvent`/`DeleteDbEvent`, filters to `BillDiscount`/`BillRefund`,
+  and drives the same QueryStore projection pipeline (`RecordProjector` + the reachable
+  `querystore.sync.*` beans) the service consumer uses. `Bill` is deliberately ignored there (it
+  already syncs via its service event).
+
+### Alternatives considered
+- **Make `BillDiscountService` / `BillRefundService` extend `OpenmrsService`.** Rejected for this PR:
+  it changes two public base-Billing services and puts them on the full core advice chain — a
+  base-module behavior change outside the integration's scope. (Left as a possible future
+  simplification.)
+- **Publish synthetic `SaveServiceEvent`s from the DB-event handler.** Rejected: it would broadcast
+  to any other service-event consumer and double the outbox signal for those entities.
+- **Fold discounts/refunds into `billing_bill`.** Rejected — see Decision 4 (staleness).
+
+### Consequences
+- All three types live-sync with **no base-Billing change**; verified live on a 2.9 standalone
+  (new discount/refund retrievable via chart search within seconds, no reindex).
+- The listener couples to QueryStore-internal seams (`RecordProjector`, the `querystore.sync.*` bean
+  ids) — a coupling the SPI explicitly sanctions for "a service that doesn't qualify contributes its
+  own event listener."
+- The DB-event listener is invoked for every entity save; it exits on a cheap `instanceof` filter.
+
+---
+
+## Decision 6: Require exact (SNAPSHOT) dependency versions
+
+### Status
+Accepted
+
+### Context
+OpenMRS's module/platform version matching ranks `X.Y.Z-SNAPSHOT` **below** a bare `X.Y.Z`. Because
+platform 2.9, querystore, and the sibling billing build are all pre-release SNAPSHOTs, bare
+requirements (`require_version 2.9.0`, `require_module querystore 1.0` / `billing 2.4`) are left
+*unsatisfied* by the running SNAPSHOT builds, and the module silently fails to start.
+
+### Decision
+Filter the `config.xml` requirements from the module's own Maven properties —
+`${openmrsPlatformVersion}` (2.9.0-SNAPSHOT), `${querystoreVersion}` (1.0.0-SNAPSHOT), and
+`${project.parent.version}` (the sibling billing version) — matching how `chartsearchai` requires
+querystore (`1.0.0-SNAPSHOT`).
+
+### Consequences
+- The module loads on the current 2.9 / querystore SNAPSHOT stack (found only by deploying to a real
+  2.9 standalone).
+- At release time the same properties resolve to release versions, so the requirements track
+  automatically.

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -98,25 +98,51 @@ omod, hard-requiring `billing` + `querystore` + platform 2.9. It is **not** in t
 Accepted
 
 ### Context
-The goal is "what would help a clinician reading the patient chart," not a full financial export.
-The billing domain has many persistent types, but only some are patient-anchored and clinically
-useful, and QueryStore only projects `OpenmrsData` (not metadata).
+The selection question is "what would help a clinician reading the patient chart" — a retrieval aid,
+not a full financial export. Two hard filters narrow the billing domain's ~15 persistent types:
+
+- **Patient-scoped.** The document must belong to a patient's chart; this drops facility/ops records.
+- **`OpenmrsData`, not `OpenmrsMetadata`.** QueryStore's projection pipeline only handles
+  `OpenmrsData` (its consumer needs `getVoided()` and routes voided → delete), so metadata types
+  cannot be indexed even if we wanted them.
+
+A third, softer consideration is *marginal value*: billed drugs/tests often already appear in the
+chart as orders/obs, so billing earns its place mainly where it adds what those don't — services
+billed but not order-entered (procedures, bed/consultation charges), and the **financial** dimension
+(an unpaid balance is a real barrier to care; a fee waiver is social context).
 
 ### Decision
-Index three patient-scoped resource types: **`billing_bill`**, **`billing_discount`**, and
-**`billing_refund`**.
-- `Bill` line items and payments are **folded into** `billing_bill` (they cascade with the bill and
-  have no independent lifecycle) — the searchable text leads with the billed services/drugs/tests.
-- Discounts and refunds are indexed as their **own** types (their lifecycles — waiver approval,
-  refund request/approval/completion — are patient-relevant in their own right).
-- Excluded: cash points, payment modes, the billable-service catalog, item prices, exemption
-  *rules*, timesheets, and sequence/infra models — facility config/ops or not patient-scoped (and,
-  being `OpenmrsMetadata` in several cases, not projectable by QueryStore anyway).
+Index three patient-scoped `OpenmrsData` types, each justified by what it tells a clinician:
+
+- **`billing_bill`** — the anchor. Its line items are a proxy for the services / drugs / tests the
+  patient was charged for (i.e. what care they received), and its status + total/paid answer "does
+  this patient owe money?". `Bill` line items and payments are **folded into** this one document
+  (they cascade with the bill and have no independent lifecycle), so the searchable text leads with
+  the billed items.
+- **`billing_discount`** — a fee waiver / discount is patient-relevant because it often signals
+  enrollment in a subsidized programme (HIV, TB, under-5, indigent) or financial hardship. Indexed
+  as its **own** type because its lifecycle (PENDING → APPROVED/REJECTED) changes independently of
+  the bill.
+- **`billing_refund`** — the weakest clinical signal (mostly administrative), included to complete
+  the record; near-free to add since it already carries its own lifecycle (REQUESTED → APPROVED →
+  COMPLETED).
+
+Excluded, with reasons:
+- **Not patient-scoped:** timesheets (cashier / shift), sequence generators and group sequences
+  (infra).
+- **Facility configuration / reference data:** cash points, payment modes (+ attribute types), the
+  billable-service catalog, item prices — they describe the facility, not a patient's care.
+- **Policy, not a per-patient record:** exemption *rules* (`BillExemption` / `BillExemptionRule`)
+  define *who* is exempt, not a given patient's exemption event.
+- Several of the above are `OpenmrsMetadata`, so the technical filter excludes them regardless.
 
 ### Consequences
-- High signal-to-noise for chart search: a clinician can find what a patient was charged for, and
-  whether an unpaid balance or a fee waiver exists.
-- Fewer types to serialize and keep in sync.
+- High signal-to-noise for chart search: a clinician can find what a patient was charged for, whether
+  there is an unpaid balance, and whether a fee waiver or refund applies.
+- Complementary to — not duplicative of — the orders/obs already indexed: billing adds the financial
+  view and any services billed outside order entry.
+- Fewer types to serialize and keep in sync; the excluded config/metadata would add noise and mostly
+  isn't projectable anyway.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -405,4 +405,23 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<profiles>
+		<!--
+			Optional QueryStore integration (produces a separate billing-querystore .omod).
+
+			It is deliberately NOT one of the default <modules>: the querystore module and the
+			core `*ServiceEvent` API it consumes (openmrs-core #6084 / TRUNK-6429) require the
+			OpenMRS platform 2.9, whereas the rest of this module still targets 2.7.8. Keeping it
+			behind a profile leaves the default build - and the base billing.omod - unchanged.
+
+			Build it with:  mvn -Pquerystore clean install
+		-->
+		<profile>
+			<id>querystore</id>
+			<modules>
+				<module>querystore</module>
+			</modules>
+		</profile>
+	</profiles>
+
 </project>

--- a/querystore/pom.xml
+++ b/querystore/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.openmrs.module</groupId>
+		<artifactId>billing</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>billing-querystore</artifactId>
+	<packaging>jar</packaging>
+	<name>OpenMRS Billing Module QueryStore Integration</name>
+	<description>
+		Projects billing records (bills, discounts, refunds) into the OpenMRS QueryStore so a
+		clinician-facing semantic/keyword chart search (e.g. chartsearchai) can retrieve them.
+		Packaged as a separate, optional billing-querystore.omod that requires the querystore module
+		and OpenMRS platform 2.9.
+	</description>
+
+	<properties>
+		<!--
+			Override the parent's 2.7.8 floor for THIS module only. The querystore SPI and the core
+			`*ServiceEvent` classes it depends on (openmrs-core #6084) are 2.9-only. Because the
+			parent's dependencyManagement pins openmrs-api/openmrs-web to ${openmrsPlatformVersion},
+			overriding the property here is enough to compile this module against 2.9.
+		-->
+		<openmrsPlatformVersion>2.9.0-SNAPSHOT</openmrsPlatformVersion>
+		<querystoreVersion>1.0.0-SNAPSHOT</querystoreVersion>
+	</properties>
+
+	<!-- querystore-api and openmrs 2.9 are still SNAPSHOTs, so snapshot resolution must be on. -->
+	<repositories>
+		<repository>
+			<id>openmrs-repo-snapshots</id>
+			<name>OpenMRS Snapshots</name>
+			<url>https://mavenrepo.openmrs.org/public</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<dependencies>
+
+		<!-- The billing domain model (Bill, BillDiscount, BillRefund, ...). Provided at runtime by
+		     the required `billing` module. -->
+		<dependency>
+			<groupId>${project.parent.groupId}</groupId>
+			<artifactId>billing-api</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- The QueryStore SPI (ResourceTypeProvider, ClinicalRecordSerializer, QueryDocument,
+		     HibernateTypeBootstrapper, BootstrapService). Provided by the required `querystore` module. -->
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>querystore-api</artifactId>
+			<version>${querystoreVersion}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Core 2.9 (brings in the DbSessionFactory the bootstrappers use, and the aop.event
+		     classes referenced by the optional fallback documented in the README). -->
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- StockItem: a line item may bill a stock item (e.g. a dispensed drug) rather than a
+		     BillableService; its name is clinically the useful part of the bill text. Provided by
+		     the stockmanagement module, which billing already requires. -->
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>stockmanagement-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Begin test dependencies -->
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openmrs.test</groupId>
+			<artifactId>openmrs-test</artifactId>
+			<type>pom</type>
+			<scope>test</scope>
+		</dependency>
+		<!-- End test dependencies -->
+
+	</dependencies>
+
+	<build>
+		<finalName>billing-querystore-${project.parent.version}</finalName>
+
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+
+		<plugins>
+			<plugin>
+				<groupId>org.openmrs.maven.plugins</groupId>
+				<artifactId>maven-openmrs-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>init</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>initialize-module</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>pack</id>
+						<phase>package</phase>
+						<goals>
+							<goal>package-module</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/BillChildDbEventListener.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/BillChildDbEventListener.java
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore;
+
+import org.openmrs.BaseOpenmrsData;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.db.event.DeleteDbEvent;
+import org.openmrs.api.db.event.SaveDbEvent;
+import org.openmrs.module.billing.api.model.BillDiscount;
+import org.openmrs.module.billing.api.model.BillRefund;
+import org.openmrs.module.querystore.events.SerializerRegistry;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+import org.openmrs.module.querystore.sync.AfterCommitDispatcher;
+import org.openmrs.module.querystore.sync.RecordIndexer;
+import org.openmrs.module.querystore.sync.RecordProjector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Live-sync for {@link BillDiscount} and {@link BillRefund}, which querystore's own
+ * {@code CoreServiceEventListener} does not pick up.
+ * <p>
+ * querystore's steady-state consumer subscribes to core's #6084 {@code *ServiceEvent}s, which are
+ * produced by an AOP advice scoped to {@code target(org.openmrs.api.OpenmrsService)}. {@code Bill}
+ * live-syncs that way because {@code BillService extends OpenmrsService}. But
+ * {@code BillDiscountService} / {@code BillRefundService} are plain interfaces, so their
+ * {@code saveBillDiscount} / {@code saveBillRefund} calls raise no {@code SaveServiceEvent} and
+ * those two types would only be indexed by the initial backfill.
+ * <p>
+ * They are, however, still persisted through Hibernate, so core's <em>non-AOP</em> path fires:
+ * {@code EventInterceptor} publishes a {@link SaveDbEvent} / {@link DeleteDbEvent} for every entity
+ * change, on the flush thread inside the originating transaction (session open) - the same
+ * conditions serialization needs. This listener consumes those DB events, filters to the two
+ * billing child types, and drives the exact same projection pipeline querystore's service consumer
+ * uses ({@link RecordProjector} + the reachable {@code querystore.sync.*} beans, per the SPI).
+ * {@code Bill} is deliberately ignored here - it already live-syncs via its
+ * {@code SaveServiceEvent}, so handling it again would be redundant (idempotent, but wasteful).
+ */
+public class BillChildDbEventListener {
+	
+	private static final Logger log = LoggerFactory.getLogger(BillChildDbEventListener.class);
+	
+	@EventListener
+	public void onSave(SaveDbEvent<?> event) {
+		project(event.getEntity(), false);
+	}
+	
+	@EventListener
+	public void onDelete(DeleteDbEvent<?> event) {
+		project(event.getEntity(), true);
+	}
+	
+	private void project(Object entity, boolean purge) {
+		// Only the billing child types whose services are not OpenmrsServices; Bill live-syncs via
+		// its own SaveServiceEvent and must not be double-projected here.
+		if (!(entity instanceof BillDiscount) && !(entity instanceof BillRefund)) {
+			return;
+		}
+		BaseOpenmrsData data = (BaseOpenmrsData) entity;
+		ClinicalRecordSerializer<BaseOpenmrsData> serializer = registry().resolve(data);
+		if (serializer == null) {
+			return;
+		}
+		try {
+			// Mirrors CoreServiceEventListener: serialize now (session open) and defer the
+			// embed + write to after-commit; the entity's own voided flag routes index-vs-delete.
+			RecordProjector.project(serializer, data, purge, indexer(), dispatcher());
+		}
+		catch (RuntimeException e) {
+			// Best-effort: a projection failure must not break the clinical transaction that saved
+			// the discount/refund (same contract as querystore's own consumer).
+			log.warn("Failed to project {} into the query store; swallowing", data.getClass().getSimpleName(), e);
+		}
+	}
+	
+	private SerializerRegistry registry() {
+		return Context.getRegisteredComponent("querystore.serializerRegistry", SerializerRegistry.class);
+	}
+	
+	private RecordIndexer indexer() {
+		return Context.getRegisteredComponent("querystore.sync.indexer", RecordIndexer.class);
+	}
+	
+	private AfterCommitDispatcher dispatcher() {
+		return Context.getRegisteredComponent("querystore.sync.dispatcher", AfterCommitDispatcher.class);
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/BillChildDbEventListener.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/BillChildDbEventListener.java
@@ -43,6 +43,11 @@ import org.springframework.context.event.EventListener;
  * uses ({@link RecordProjector} + the reachable {@code querystore.sync.*} beans, per the SPI).
  * {@code Bill} is deliberately ignored here - it already live-syncs via its
  * {@code SaveServiceEvent}, so handling it again would be redundant (idempotent, but wasteful).
+ * <p>
+ * Because {@code SaveDbEvent} fires for <em>every</em> entity, {@link #project} takes a raw
+ * {@code SaveDbEvent<?>} and matches its two types with a cheap, proxy-safe {@code instanceof} -
+ * mirroring querystore's own {@code CoreServiceEventListener}, which likewise consumes
+ * {@code SaveServiceEvent<?>} and filters by type.
  */
 public class BillChildDbEventListener {
 	
@@ -65,18 +70,18 @@ public class BillChildDbEventListener {
 			return;
 		}
 		BaseOpenmrsData data = (BaseOpenmrsData) entity;
-		ClinicalRecordSerializer<BaseOpenmrsData> serializer = registry().resolve(data);
-		if (serializer == null) {
-			return;
-		}
 		try {
-			// Mirrors CoreServiceEventListener: serialize now (session open) and defer the
-			// embed + write to after-commit; the entity's own voided flag routes index-vs-delete.
+			// Resolve + serialize now (session open); RecordProjector defers the embed + write to
+			// after-commit, and the entity's own voided flag routes index-vs-delete. The querystore
+			// bean lookups sit inside the try too, so an infra hiccup can't escape into - and roll
+			// back - the clinical transaction that saved the discount/refund.
+			ClinicalRecordSerializer<BaseOpenmrsData> serializer = registry().resolve(data);
+			if (serializer == null) {
+				return;
+			}
 			RecordProjector.project(serializer, data, purge, indexer(), dispatcher());
 		}
 		catch (RuntimeException e) {
-			// Best-effort: a projection failure must not break the clinical transaction that saved
-			// the discount/refund (same contract as querystore's own consumer).
 			log.warn("Failed to project {} into the query store; swallowing", data.getClass().getSimpleName(), e);
 		}
 	}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/BillingQuerystoreActivator.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/BillingQuerystoreActivator.java
@@ -16,13 +16,15 @@ import org.slf4j.LoggerFactory;
 /**
  * Lifecycle hooks for the billing &lt;-&gt; query store integration.
  * <p>
- * No wiring happens here: the {@code ResourceTypeProvider}, serializer and bootstrapper beans are
- * registered in {@code moduleApplicationContext.xml} and discovered by querystore through
- * {@code Context.getRegisteredComponents(...)}. Steady-state indexing is driven by the core
- * {@code *ServiceEvent}s that billing's {@code save*}/{@code void*}/{@code purge*} service methods
- * emit (openmrs-core #6084), so nothing needs to be started here.
+ * No wiring happens here: the {@code ResourceTypeProvider}, serializer, bootstrapper and
+ * {@link BillChildDbEventListener} beans are all registered in {@code moduleApplicationContext.xml}
+ * and discovered by querystore / Spring. Steady-state indexing therefore needs nothing started
+ * here, and it flows through two paths: {@code Bill} rides core #6084's {@code *ServiceEvent}s (its
+ * {@code BillService} is an {@code OpenmrsService}, which querystore's own consumer handles), while
+ * {@code BillDiscount} / {@code BillRefund} are projected by {@link BillChildDbEventListener} from
+ * core's Hibernate {@code SaveDbEvent}s (their services are not {@code OpenmrsService}s).
  * <p>
- * Initial backfill of pre-existing bills is deliberately <em>not</em> auto-run from here (a full
+ * Initial backfill of pre-existing records is deliberately <em>not</em> auto-run from here (a full
  * scan should not block module startup). Trigger it once, admin-side, via querystore's reindex
  * endpoint ({@code POST /ws/rest/v1/querystore/reindex {"scope":"all"}}) or
  * {@code BootstrapService.bootstrap(...)}.

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/BillingQuerystoreActivator.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/BillingQuerystoreActivator.java
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore;
+
+import org.openmrs.module.BaseModuleActivator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lifecycle hooks for the billing &lt;-&gt; query store integration.
+ * <p>
+ * No wiring happens here: the {@code ResourceTypeProvider}, serializer and bootstrapper beans are
+ * registered in {@code moduleApplicationContext.xml} and discovered by querystore through
+ * {@code Context.getRegisteredComponents(...)}. Steady-state indexing is driven by the core
+ * {@code *ServiceEvent}s that billing's {@code save*}/{@code void*}/{@code purge*} service methods
+ * emit (openmrs-core #6084), so nothing needs to be started here.
+ * <p>
+ * Initial backfill of pre-existing bills is deliberately <em>not</em> auto-run from here (a full
+ * scan should not block module startup). Trigger it once, admin-side, via querystore's reindex
+ * endpoint ({@code POST /ws/rest/v1/querystore/reindex {"scope":"all"}}) or
+ * {@code BootstrapService.bootstrap(...)}.
+ */
+public class BillingQuerystoreActivator extends BaseModuleActivator {
+	
+	private static final Logger log = LoggerFactory.getLogger(BillingQuerystoreActivator.class);
+	
+	@Override
+	public void started() {
+		log.info("Billing QueryStore integration started - billing_bill, billing_discount and "
+		        + "billing_refund resource types registered with the query store");
+	}
+	
+	@Override
+	public void stopped() {
+		log.info("Billing QueryStore integration stopped");
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillBootstrapper.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillBootstrapper.java
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.bootstrap;
+
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.querystore.serialization.BillRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.HibernateTypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+
+/**
+ * Backfills existing {@link Bill}s into the query store. Bill maps both {@code patient} (not-null)
+ * and {@code dateChanged}, so the base HibernateTypeBootstrapper defaults ({@code e.patient.uuid}
+ * scope, {@code COALESCE(e.dateChanged, e.dateCreated)} cursor) apply unchanged.
+ */
+public class BillBootstrapper extends HibernateTypeBootstrapper<Bill> {
+	
+	private final BillRecordSerializer serializer;
+	
+	public BillBootstrapper(BillRecordSerializer serializer, DbSessionFactory sessionFactory) {
+		super(sessionFactory);
+		this.serializer = serializer;
+	}
+	
+	@Override
+	protected ClinicalRecordSerializer<Bill> getSerializer() {
+		return serializer;
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillDiscountBootstrapper.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillDiscountBootstrapper.java
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.bootstrap;
+
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.module.billing.api.model.BillDiscount;
+import org.openmrs.module.billing.querystore.serialization.BillDiscountRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.HibernateTypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+
+/**
+ * Backfills existing {@link BillDiscount}s. A discount is patient-scoped through its parent bill,
+ * so the patient association is {@code e.bill.patient.uuid} (which also forces the inner joins that
+ * drop any dump-orphaned bill/patient FK). It is a JPA {@code @Entity} extending
+ * {@code BaseOpenmrsData} and does not map {@code dateChanged}, so the cursor uses
+ * {@code e.dateCreated} - live sync handles later status changes, so the backfill cursor only needs
+ * to be monotonic for a single pass.
+ */
+public class BillDiscountBootstrapper extends HibernateTypeBootstrapper<BillDiscount> {
+	
+	private final BillDiscountRecordSerializer serializer;
+	
+	public BillDiscountBootstrapper(BillDiscountRecordSerializer serializer, DbSessionFactory sessionFactory) {
+		super(sessionFactory);
+		this.serializer = serializer;
+	}
+	
+	@Override
+	protected ClinicalRecordSerializer<BillDiscount> getSerializer() {
+		return serializer;
+	}
+	
+	@Override
+	protected String patientAssociationExpr() {
+		return "e.bill.patient.uuid";
+	}
+	
+	@Override
+	protected String cursorDateExpr() {
+		return "e.dateCreated";
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillRefundBootstrapper.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/bootstrap/BillRefundBootstrapper.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.bootstrap;
+
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.module.billing.api.model.BillRefund;
+import org.openmrs.module.billing.querystore.serialization.BillRefundRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.HibernateTypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+
+/**
+ * Backfills existing {@link BillRefund}s. Patient-scoped through the parent bill
+ * ({@code e.bill.patient.uuid}); like {@link BillDiscountBootstrapper} it is a JPA {@code @Entity}
+ * that does not map {@code dateChanged}, so the cursor uses {@code e.dateCreated}.
+ */
+public class BillRefundBootstrapper extends HibernateTypeBootstrapper<BillRefund> {
+	
+	private final BillRefundRecordSerializer serializer;
+	
+	public BillRefundBootstrapper(BillRefundRecordSerializer serializer, DbSessionFactory sessionFactory) {
+		super(sessionFactory);
+		this.serializer = serializer;
+	}
+	
+	@Override
+	protected ClinicalRecordSerializer<BillRefund> getSerializer() {
+		return serializer;
+	}
+	
+	@Override
+	protected String patientAssociationExpr() {
+		return "e.bill.patient.uuid";
+	}
+	
+	@Override
+	protected String cursorDateExpr() {
+		return "e.dateCreated";
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
@@ -21,28 +21,28 @@ import org.openmrs.module.querystore.util.DateFormatUtil;
  * Base for the billing record types that hang off a parent {@link Bill} (discounts, refunds). It
  * centralizes the "child-of-bill" cross-cutting fields those types share: patient scope via the
  * parent bill, the resource uuid, the record date, and the parent-bill reference metadata
- * ({@code bill_uuid} + {@code receipt_number}). Subclasses supply {@link #billOf(BaseOpenmrsData)}
- * and their type-specific {@link #populate} text/metadata.
+ * ({@code bill_uuid} + {@code receipt_number}). Subclasses supply {@link #billOf} and their
+ * type-specific {@link #populate} text/metadata.
  */
 abstract class AbstractBillChildRecordSerializer<T extends BaseOpenmrsData> extends AbstractRecordSerializer<T> {
 	
-	/** The parent bill this record hangs off (its patient is the document's scope). */
-	protected abstract Bill billOf(T record);
+	/** The parent bill this entity hangs off (its patient is the document's scope). */
+	protected abstract Bill billOf(T entity);
 	
 	@Override
-	protected String getPatientUuid(T record) {
-		Bill bill = billOf(record);
+	protected String getPatientUuid(T entity) {
+		Bill bill = billOf(entity);
 		return bill != null && bill.getPatient() != null ? bill.getPatient().getUuid() : null;
 	}
 	
 	@Override
-	protected String getResourceUuid(T record) {
-		return record.getUuid();
+	protected String getResourceUuid(T entity) {
+		return entity.getUuid();
 	}
 	
 	@Override
-	protected LocalDate getDate(T record) {
-		return DateFormatUtil.toLocalDate(record.getDateCreated());
+	protected LocalDate getDate(T entity) {
+		return DateFormatUtil.toLocalDate(entity.getDateCreated());
 	}
 	
 	/** Trimmed receipt number of the parent bill (used in both text and metadata), or null. */

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import java.time.LocalDate;
+
+import org.openmrs.BaseOpenmrsData;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.querystore.model.QueryDocument;
+import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
+import org.openmrs.module.querystore.util.DateFormatUtil;
+
+/**
+ * Base for the billing record types that hang off a parent {@link Bill} (discounts, refunds). It
+ * centralizes the "child-of-bill" cross-cutting fields those types share: patient scope via the
+ * parent bill, the resource uuid, the record date, and the parent-bill reference metadata
+ * ({@code bill_uuid} + {@code receipt_number}). Subclasses supply {@link #billOf(BaseOpenmrsData)}
+ * and their type-specific {@link #populate} text/metadata.
+ */
+abstract class AbstractBillChildRecordSerializer<T extends BaseOpenmrsData> extends AbstractRecordSerializer<T> {
+	
+	/** The parent bill this record hangs off (its patient is the document's scope). */
+	protected abstract Bill billOf(T record);
+	
+	@Override
+	protected String getPatientUuid(T record) {
+		Bill bill = billOf(record);
+		return bill != null && bill.getPatient() != null ? bill.getPatient().getUuid() : null;
+	}
+	
+	@Override
+	protected String getResourceUuid(T record) {
+		return record.getUuid();
+	}
+	
+	@Override
+	protected LocalDate getDate(T record) {
+		return DateFormatUtil.toLocalDate(record.getDateCreated());
+	}
+	
+	/** Trimmed receipt number of the parent bill (used in both text and metadata), or null. */
+	protected final String receiptOf(Bill bill) {
+		return bill != null ? trimToNull(bill.getReceiptNumber()) : null;
+	}
+	
+	/**
+	 * Writes the shared parent-bill reference metadata: {@code bill_uuid} and {@code receipt_number}.
+	 */
+	protected final void putBillReference(QueryDocument doc, Bill bill, String receipt) {
+		if (bill != null && bill.getUuid() != null) {
+			doc.putMetadata(BillingQueryFields.BILL_UUID, bill.getUuid());
+		}
+		if (receipt != null) {
+			doc.putMetadata(BillingQueryFields.RECEIPT_NUMBER, receipt);
+		}
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/AbstractBillChildRecordSerializer.java
@@ -23,6 +23,12 @@ import org.openmrs.module.querystore.util.DateFormatUtil;
  * parent bill, the resource uuid, the record date, and the parent-bill reference metadata
  * ({@code bill_uuid} + {@code receipt_number}). Subclasses supply {@link #billOf} and their
  * type-specific {@link #populate} text/metadata.
+ * <p>
+ * <b>Flush-thread constraint.</b> These types live-sync from a Hibernate flush (via
+ * {@code BillChildDbEventListener} consuming core's {@code SaveDbEvent}), so {@link #populate} may
+ * run on the flush thread. It must therefore navigate only id-loadable to-one proxies (as
+ * {@link #getPatientUuid} / {@link #receiptOf} do: bill → patient / receipt number) and must not
+ * issue a query or force a lazy collection, which could trigger a flush-inside-flush.
  */
 abstract class AbstractBillChildRecordSerializer<T extends BaseOpenmrsData> extends AbstractRecordSerializer<T> {
 	

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
@@ -1,0 +1,112 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
+
+import java.time.LocalDate;
+
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillDiscount;
+import org.openmrs.module.billing.api.model.DiscountType;
+import org.openmrs.module.querystore.model.QueryDocument;
+import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
+import org.openmrs.module.querystore.util.DateFormatUtil;
+
+/**
+ * Serializes a {@link BillDiscount} into a {@code billing_discount} document. A discount / fee
+ * waiver is patient-relevant because it often signals a subsidized programme (HIV, TB, under-5,
+ * indigent) or financial hardship. It is indexed as its own type - rather than folded into the bill
+ * - because its lifecycle (PENDING -> APPROVED/REJECTED) is driven through its own
+ * {@code saveBillDiscount} service call, so its own save events keep the projection current without
+ * re-saving the bill.
+ */
+public class BillDiscountRecordSerializer extends AbstractRecordSerializer<BillDiscount> {
+	
+	public static final String RESOURCE_TYPE = "billing_discount";
+	
+	@Override
+	public String getResourceType() {
+		return RESOURCE_TYPE;
+	}
+	
+	@Override
+	public Class<BillDiscount> getSupportedType() {
+		return BillDiscount.class;
+	}
+	
+	@Override
+	protected String getPatientUuid(BillDiscount discount) {
+		Bill bill = discount.getBill();
+		if (bill == null || bill.getPatient() == null) {
+			return null;
+		}
+		return bill.getPatient().getUuid();
+	}
+	
+	@Override
+	protected String getResourceUuid(BillDiscount discount) {
+		return discount.getUuid();
+	}
+	
+	@Override
+	protected LocalDate getDate(BillDiscount discount) {
+		return discount.getDateCreated() != null ? DateFormatUtil.toLocalDate(discount.getDateCreated()) : null;
+	}
+	
+	@Override
+	protected void populate(BillDiscount discount, QueryDocument doc) {
+		Bill bill = discount.getBill();
+		String receipt = bill != null ? trimToNull(bill.getReceiptNumber()) : null;
+		
+		StringBuilder text = new StringBuilder("Bill discount");
+		if (receipt != null) {
+			text.append(" on bill ").append(receipt);
+		}
+		text.append(": ").append(describeAmount(discount));
+		if (discount.getStatus() != null) {
+			text.append(". Status: ").append(readable(discount.getStatus().name()));
+		}
+		String justification = trimToNull(discount.getJustification());
+		if (justification != null) {
+			text.append(". Justification: ").append(justification);
+		}
+		text.append('.');
+		doc.setText(text.toString());
+		
+		if (discount.getStatus() != null) {
+			doc.putMetadata("discount_status", discount.getStatus().name());
+		}
+		if (discount.getDiscountType() != null) {
+			doc.putMetadata("discount_type", discount.getDiscountType().name());
+		}
+		if (discount.getDiscountValue() != null) {
+			doc.putMetadata("discount_value", money(discount.getDiscountValue()));
+		}
+		doc.putMetadata("discount_amount", money(discount.getDiscountAmount()));
+		if (bill != null && bill.getUuid() != null) {
+			doc.putMetadata("bill_uuid", bill.getUuid());
+		}
+		if (receipt != null) {
+			doc.putMetadata("receipt_number", receipt);
+		}
+	}
+	
+	private static String describeAmount(BillDiscount discount) {
+		DiscountType type = discount.getDiscountType();
+		if (type == DiscountType.PERCENTAGE && discount.getDiscountValue() != null) {
+			return money(discount.getDiscountValue()) + "% (" + money(discount.getDiscountAmount()) + ")";
+		}
+		// FIXED_AMOUNT (or an unspecified type): the amount is the value itself.
+		return money(discount.getDiscountAmount());
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
@@ -27,6 +27,12 @@ import org.openmrs.module.querystore.model.QueryDocument;
  * advice never fires for {@code saveBillDiscount}; live-sync is instead handled by
  * {@link org.openmrs.module.billing.querystore.BillChildDbEventListener} (core's non-AOP Hibernate
  * {@code SaveDbEvent}), with initial backfill by {@code BillDiscountBootstrapper}.
+ * <p>
+ * Note: for a PERCENTAGE discount, {@code discount_amount} (and the amount shown in the text) is
+ * derived from the bill total at projection time. If the bill total later changes without the
+ * discount being re-saved, that figure can lag until the discount's next save — the same
+ * cross-entity eventual-consistency the ADR notes for {@code billing_bill}. The intrinsic
+ * {@code discount_percent} is always current.
  */
 public class BillDiscountRecordSerializer extends AbstractBillChildRecordSerializer<BillDiscount> {
 	

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
@@ -22,9 +22,11 @@ import org.openmrs.module.querystore.model.QueryDocument;
  * Serializes a {@link BillDiscount} into a {@code billing_discount} document. A discount / fee
  * waiver is patient-relevant because it often signals a subsidized programme (HIV, TB, under-5,
  * indigent) or financial hardship. It is indexed as its own type - rather than folded into the bill
- * - because its lifecycle (PENDING -> APPROVED/REJECTED) is driven through its own
- * {@code saveBillDiscount} service call, so its own save events keep the projection current without
- * re-saving the bill.
+ * - because its lifecycle (PENDING -> APPROVED/REJECTED) changes independently of the bill.
+ * {@code BillDiscountService} is not an {@code OpenmrsService}, so core #6084's service-event
+ * advice never fires for {@code saveBillDiscount}; live-sync is instead handled by
+ * {@link org.openmrs.module.billing.querystore.BillChildDbEventListener} (core's non-AOP Hibernate
+ * {@code SaveDbEvent}), with initial backfill by {@code BillDiscountBootstrapper}.
  */
 public class BillDiscountRecordSerializer extends AbstractBillChildRecordSerializer<BillDiscount> {
 	

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDiscountRecordSerializer.java
@@ -10,17 +10,13 @@
 package org.openmrs.module.billing.querystore.serialization;
 
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.plain;
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
-import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
-
-import java.time.LocalDate;
 
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillDiscount;
 import org.openmrs.module.billing.api.model.DiscountType;
 import org.openmrs.module.querystore.model.QueryDocument;
-import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
-import org.openmrs.module.querystore.util.DateFormatUtil;
 
 /**
  * Serializes a {@link BillDiscount} into a {@code billing_discount} document. A discount / fee
@@ -30,7 +26,7 @@ import org.openmrs.module.querystore.util.DateFormatUtil;
  * {@code saveBillDiscount} service call, so its own save events keep the projection current without
  * re-saving the bill.
  */
-public class BillDiscountRecordSerializer extends AbstractRecordSerializer<BillDiscount> {
+public class BillDiscountRecordSerializer extends AbstractBillChildRecordSerializer<BillDiscount> {
 	
 	public static final String RESOURCE_TYPE = "billing_discount";
 	
@@ -45,34 +41,24 @@ public class BillDiscountRecordSerializer extends AbstractRecordSerializer<BillD
 	}
 	
 	@Override
-	protected String getPatientUuid(BillDiscount discount) {
-		Bill bill = discount.getBill();
-		if (bill == null || bill.getPatient() == null) {
-			return null;
-		}
-		return bill.getPatient().getUuid();
-	}
-	
-	@Override
-	protected String getResourceUuid(BillDiscount discount) {
-		return discount.getUuid();
-	}
-	
-	@Override
-	protected LocalDate getDate(BillDiscount discount) {
-		return discount.getDateCreated() != null ? DateFormatUtil.toLocalDate(discount.getDateCreated()) : null;
+	protected Bill billOf(BillDiscount discount) {
+		return discount.getBill();
 	}
 	
 	@Override
 	protected void populate(BillDiscount discount, QueryDocument doc) {
+		if (doc.getPatientUuid() == null) {
+			return; // no patient scope (unreachable: bill/patient are NOT NULL FKs) - skip, matching backfill
+		}
 		Bill bill = discount.getBill();
-		String receipt = bill != null ? trimToNull(bill.getReceiptNumber()) : null;
+		String receipt = receiptOf(bill);
+		boolean hasPercent = discount.getDiscountType() == DiscountType.PERCENTAGE && discount.getDiscountValue() != null;
 		
 		StringBuilder text = new StringBuilder("Bill discount");
 		if (receipt != null) {
 			text.append(" on bill ").append(receipt);
 		}
-		text.append(": ").append(describeAmount(discount));
+		text.append(": ").append(describeAmount(discount, hasPercent));
 		if (discount.getStatus() != null) {
 			text.append(". Status: ").append(readable(discount.getStatus().name()));
 		}
@@ -84,29 +70,25 @@ public class BillDiscountRecordSerializer extends AbstractRecordSerializer<BillD
 		doc.setText(text.toString());
 		
 		if (discount.getStatus() != null) {
-			doc.putMetadata("discount_status", discount.getStatus().name());
+			doc.putMetadata(BillingQueryFields.DISCOUNT_STATUS, discount.getStatus().name());
 		}
 		if (discount.getDiscountType() != null) {
-			doc.putMetadata("discount_type", discount.getDiscountType().name());
+			doc.putMetadata(BillingQueryFields.DISCOUNT_TYPE, discount.getDiscountType().name());
 		}
-		if (discount.getDiscountValue() != null) {
-			doc.putMetadata("discount_value", money(discount.getDiscountValue()));
+		// A single unit-ambiguous "discount_value" (percent for PERCENTAGE, currency for FIXED_AMOUNT)
+		// would break numeric filtering, so expose the percentage only for PERCENTAGE and always the
+		// resolved currency amount.
+		if (hasPercent) {
+			doc.putMetadata(BillingQueryFields.DISCOUNT_PERCENT, plain(discount.getDiscountValue()));
 		}
-		doc.putMetadata("discount_amount", money(discount.getDiscountAmount()));
-		if (bill != null && bill.getUuid() != null) {
-			doc.putMetadata("bill_uuid", bill.getUuid());
-		}
-		if (receipt != null) {
-			doc.putMetadata("receipt_number", receipt);
-		}
+		doc.putMetadata(BillingQueryFields.DISCOUNT_AMOUNT, money(discount.getDiscountAmount()));
+		putBillReference(doc, bill, receipt);
 	}
 	
-	private static String describeAmount(BillDiscount discount) {
-		DiscountType type = discount.getDiscountType();
-		if (type == DiscountType.PERCENTAGE && discount.getDiscountValue() != null) {
-			return money(discount.getDiscountValue()) + "% (" + money(discount.getDiscountAmount()) + ")";
+	private static String describeAmount(BillDiscount discount, boolean hasPercent) {
+		if (hasPercent) {
+			return plain(discount.getDiscountValue()) + "% (" + money(discount.getDiscountAmount()) + ")";
 		}
-		// FIXED_AMOUNT (or an unspecified type): the amount is the value itself.
 		return money(discount.getDiscountAmount());
 	}
 }

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDocFormat.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDocFormat.java
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import java.math.BigDecimal;
+
+/**
+ * Small formatting helpers shared by the billing record serializers so bill, discount and refund
+ * documents render money and enum/status text the same way.
+ */
+final class BillDocFormat {
+	
+	private BillDocFormat() {
+	}
+	
+	/** Plain (non-scientific, no grouping) decimal string; treats null as zero. */
+	static String money(BigDecimal amount) {
+		return (amount != null ? amount : BigDecimal.ZERO).toPlainString();
+	}
+	
+	/** Turns an enum constant such as {@code PARTIALLY_REFUNDED} into {@code partially refunded}. */
+	static String readable(String enumName) {
+		return enumName == null ? "" : enumName.toLowerCase().replace('_', ' ');
+	}
+	
+	/** Trims and returns null when null/blank, so callers null-check once. */
+	static String trimToNull(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDocFormat.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillDocFormat.java
@@ -12,30 +12,30 @@ package org.openmrs.module.billing.querystore.serialization;
 import java.math.BigDecimal;
 
 /**
- * Small formatting helpers shared by the billing record serializers so bill, discount and refund
- * documents render money and enum/status text the same way.
+ * Billing-specific formatting helpers shared by the bill / discount / refund serializers so money
+ * and enum-status text render the same way in every document. (String trimming is provided by the
+ * SPI base {@code AbstractRecordSerializer.trimToNull}.)
  */
 final class BillDocFormat {
 	
 	private BillDocFormat() {
 	}
 	
-	/** Plain (non-scientific, no grouping) decimal string; treats null as zero. */
+	/**
+	 * Plain (non-scientific, no grouping) decimal string; treats null as zero. Use for a bare numeric
+	 * value such as a percentage, where {@link #money} would misread at the call site.
+	 */
+	static String plain(BigDecimal value) {
+		return (value != null ? value : BigDecimal.ZERO).toPlainString();
+	}
+	
+	/** A currency amount rendered as a plain decimal string; treats null as zero. */
 	static String money(BigDecimal amount) {
-		return (amount != null ? amount : BigDecimal.ZERO).toPlainString();
+		return plain(amount);
 	}
 	
 	/** Turns an enum constant such as {@code PARTIALLY_REFUNDED} into {@code partially refunded}. */
 	static String readable(String enumName) {
 		return enumName == null ? "" : enumName.toLowerCase().replace('_', ' ');
-	}
-	
-	/** Trims and returns null when null/blank, so callers null-check once. */
-	static String trimToNull(String value) {
-		if (value == null) {
-			return null;
-		}
-		String trimmed = value.trim();
-		return trimmed.isEmpty() ? null : trimmed;
 	}
 }

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
@@ -1,0 +1,213 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openmrs.Drug;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.Payment;
+import org.openmrs.module.querystore.model.QueryDocument;
+import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
+import org.openmrs.module.querystore.util.DateFormatUtil;
+import org.openmrs.module.stockmanagement.api.model.StockItem;
+
+/**
+ * Serializes a {@link Bill} into a single, clinician-oriented {@code billing_bill} document.
+ * <p>
+ * A bill is the patient-anchored unit here: its line items (the services / drugs / tests the
+ * patient was charged for) and its payments cascade with it and are always current when the bill is
+ * saved, so they are folded into this one document rather than indexed separately. The searchable
+ * {@code text} leads with the billed items - what a clinician reading the chart would actually
+ * search for - and carries the payment picture (total, paid, outstanding balance, status) so a
+ * cost-of-care / affordability signal is retrievable too.
+ */
+public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
+	
+	public static final String RESOURCE_TYPE = "billing_bill";
+	
+	static final String FIELD_BILL_STATUS = "bill_status";
+	
+	static final String FIELD_RECEIPT_NUMBER = "receipt_number";
+	
+	static final String FIELD_TOTAL = "total";
+	
+	static final String FIELD_AMOUNT_PAID = "amount_paid";
+	
+	static final String FIELD_BALANCE = "balance";
+	
+	static final String FIELD_CASH_POINT = "cash_point";
+	
+	static final String FIELD_VISIT_UUID = "visit_uuid";
+	
+	static final String FIELD_SERVICES = "services";
+	
+	static final String FIELD_PAYMENT_MODES = "payment_modes";
+	
+	static final String FIELD_LINE_ITEM_COUNT = "line_item_count";
+	
+	@Override
+	public String getResourceType() {
+		return RESOURCE_TYPE;
+	}
+	
+	@Override
+	public Class<Bill> getSupportedType() {
+		return Bill.class;
+	}
+	
+	@Override
+	protected String getPatientUuid(Bill bill) {
+		return bill.getPatient() != null ? bill.getPatient().getUuid() : null;
+	}
+	
+	@Override
+	protected String getResourceUuid(Bill bill) {
+		return bill.getUuid();
+	}
+	
+	@Override
+	protected LocalDate getDate(Bill bill) {
+		return bill.getDateCreated() != null ? DateFormatUtil.toLocalDate(bill.getDateCreated()) : null;
+	}
+	
+	@Override
+	protected void populate(Bill bill, QueryDocument doc) {
+		List<String> services = billedItemLabels(bill);
+		
+		BigDecimal total = bill.getTotal();
+		BigDecimal afterDiscount = bill.getAmountAfterDiscount();
+		BigDecimal paid = bill.getTotalPayments();
+		BigDecimal balance = afterDiscount.subtract(paid);
+		
+		StringBuilder text = new StringBuilder("Bill");
+		String receipt = trimToNull(bill.getReceiptNumber());
+		if (receipt != null) {
+			text.append(' ').append(receipt);
+		}
+		if (bill.getStatus() != null) {
+			text.append(". Status: ").append(readable(bill.getStatus().name()));
+		}
+		if (!services.isEmpty()) {
+			text.append(". Services billed: ").append(String.join(", ", services));
+		}
+		text.append(". Total: ").append(money(total));
+		if (afterDiscount.compareTo(total) != 0) {
+			text.append(" (after discount ").append(money(afterDiscount)).append(')');
+		}
+		text.append(", paid: ").append(money(paid)).append(", balance: ").append(money(balance));
+		String cashPoint = bill.getCashPoint() != null ? trimToNull(bill.getCashPoint().getName()) : null;
+		if (cashPoint != null) {
+			text.append(". Cash point: ").append(cashPoint);
+		}
+		text.append('.');
+		doc.setText(text.toString());
+		
+		if (bill.getStatus() != null) {
+			doc.putMetadata(FIELD_BILL_STATUS, bill.getStatus().name());
+		}
+		if (receipt != null) {
+			doc.putMetadata(FIELD_RECEIPT_NUMBER, receipt);
+		}
+		doc.putMetadata(FIELD_TOTAL, money(afterDiscount));
+		doc.putMetadata(FIELD_AMOUNT_PAID, money(paid));
+		doc.putMetadata(FIELD_BALANCE, money(balance));
+		if (cashPoint != null) {
+			doc.putMetadata(FIELD_CASH_POINT, cashPoint);
+		}
+		if (bill.getVisit() != null) {
+			doc.putMetadata(FIELD_VISIT_UUID, bill.getVisit().getUuid());
+		}
+		if (!services.isEmpty()) {
+			doc.putMetadata(FIELD_SERVICES, services);
+			doc.putMetadata(FIELD_LINE_ITEM_COUNT, services.size());
+		}
+		List<String> modes = paymentModes(bill);
+		if (!modes.isEmpty()) {
+			doc.putMetadata(FIELD_PAYMENT_MODES, modes);
+		}
+	}
+	
+	/**
+	 * Human-readable label for each non-voided line item, preferring the billable service name and
+	 * falling back to the stock item (dispensed drug / supply) or the price name.
+	 */
+	private static List<String> billedItemLabels(Bill bill) {
+		List<String> labels = new ArrayList<String>();
+		if (bill.getLineItems() == null) {
+			return labels;
+		}
+		for (BillLineItem item : bill.getLineItems()) {
+			if (item == null || Boolean.TRUE.equals(item.getVoided())) {
+				continue;
+			}
+			String label = labelFor(item);
+			if (label == null) {
+				continue;
+			}
+			if (item.getQuantity() != null && item.getQuantity() != 1) {
+				label = label + " (x" + item.getQuantity() + ")";
+			}
+			labels.add(label);
+		}
+		return labels;
+	}
+	
+	private static String labelFor(BillLineItem item) {
+		if (item.getBillableService() != null) {
+			String name = trimToNull(item.getBillableService().getName());
+			if (name != null) {
+				return name;
+			}
+		}
+		StockItem stockItem = item.getItem();
+		if (stockItem != null) {
+			String common = trimToNull(stockItem.getCommonName());
+			if (common != null) {
+				return common;
+			}
+			Drug drug = stockItem.getDrug();
+			if (drug != null) {
+				String drugName = trimToNull(drug.getName());
+				if (drugName != null) {
+					return drugName;
+				}
+			}
+		}
+		return trimToNull(item.getPriceName());
+	}
+	
+	private static List<String> paymentModes(Bill bill) {
+		List<String> modes = new ArrayList<String>();
+		if (bill.getPayments() == null) {
+			return modes;
+		}
+		for (Payment payment : bill.getPayments()) {
+			if (payment == null || Boolean.TRUE.equals(payment.getVoided())) {
+				continue;
+			}
+			if (payment.getInstanceType() != null) {
+				String name = trimToNull(payment.getInstanceType().getName());
+				if (name != null && !modes.contains(name)) {
+					modes.add(name);
+				}
+			}
+		}
+		return modes;
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
@@ -11,12 +11,15 @@ package org.openmrs.module.billing.querystore.serialization;
 
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
-import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
+import static org.openmrs.module.querystore.QueryStoreConstants.FIELD_VISIT_UUID;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.openmrs.Drug;
 import org.openmrs.module.billing.api.model.Bill;
@@ -31,35 +34,31 @@ import org.openmrs.module.stockmanagement.api.model.StockItem;
  * Serializes a {@link Bill} into a single, clinician-oriented {@code billing_bill} document.
  * <p>
  * A bill is the patient-anchored unit here: its line items (the services / drugs / tests the
- * patient was charged for) and its payments cascade with it and are always current when the bill is
- * saved, so they are folded into this one document rather than indexed separately. The searchable
- * {@code text} leads with the billed items - what a clinician reading the chart would actually
- * search for - and carries the payment picture (total, paid, outstanding balance, status) so a
- * cost-of-care / affordability signal is retrievable too.
+ * patient was charged for) and its payments cascade with it and are persisted atomically on
+ * {@code saveBill}, so they are folded into this one document rather than indexed separately. The
+ * searchable {@code text} leads with the billed items - what a clinician reading the chart would
+ * actually search for - then the raw total, amount paid and status.
+ * <p>
+ * <b>Only bill-aggregate-derived, always-refreshed fields are folded in.</b> The projection is
+ * re-run by querystore's events consumer whenever a {@code *ServiceEvent} fires for the bill
+ * ({@code saveBill} / {@code voidBill} / {@code purgeBill}), so a folded field is only kept current
+ * if every mutation that changes it re-saves the bill. That holds for line items, payments and
+ * status. It deliberately does <em>not</em> hold for the discount-adjusted total / outstanding
+ * balance: approving a fee waiver goes through {@code BillDiscountService.saveBillDiscount}, which
+ * persists the discount alone and does not re-save the bill - so a denormalized "amount after
+ * discount" here would silently overstate what the patient owes until the bill's next save. We
+ * therefore expose the raw (pre-discount) line-item {@code total} plus {@code amount_paid} and
+ * leave discount detail to the {@code billing_discount} document; {@code status} conveys
+ * settled-ness.
+ * <p>
+ * Residual eventual-consistency: the dedicated single-child endpoints ({@code voidBillLineItem},
+ * discount approval) mutate bill-child state without re-saving the bill, so a folded item can lag
+ * until the bill's next save. Acceptable for a retrieval index and self-healing; authoritative
+ * figures live in the billing UI/API.
  */
 public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 	
 	public static final String RESOURCE_TYPE = "billing_bill";
-	
-	static final String FIELD_BILL_STATUS = "bill_status";
-	
-	static final String FIELD_RECEIPT_NUMBER = "receipt_number";
-	
-	static final String FIELD_TOTAL = "total";
-	
-	static final String FIELD_AMOUNT_PAID = "amount_paid";
-	
-	static final String FIELD_BALANCE = "balance";
-	
-	static final String FIELD_CASH_POINT = "cash_point";
-	
-	static final String FIELD_VISIT_UUID = "visit_uuid";
-	
-	static final String FIELD_SERVICES = "services";
-	
-	static final String FIELD_PAYMENT_MODES = "payment_modes";
-	
-	static final String FIELD_LINE_ITEM_COUNT = "line_item_count";
 	
 	@Override
 	public String getResourceType() {
@@ -83,17 +82,23 @@ public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 	
 	@Override
 	protected LocalDate getDate(Bill bill) {
-		return bill.getDateCreated() != null ? DateFormatUtil.toLocalDate(bill.getDateCreated()) : null;
+		return DateFormatUtil.toLocalDate(bill.getDateCreated());
 	}
 	
 	@Override
 	protected void populate(Bill bill, QueryDocument doc) {
+		if (doc.getPatientUuid() == null) {
+			// No patient scope (unreachable for a persisted bill - patient is a NOT NULL FK). Leaving
+			// text unset makes serialize() skip it, matching the backfill scan's patient IS NOT NULL filter.
+			return;
+		}
+		
 		List<String> services = billedItemLabels(bill);
 		
+		// Raw line-item total (discount-independent). See the class javadoc for why the
+		// discount-adjusted total/balance are intentionally not folded in here.
 		BigDecimal total = bill.getTotal();
-		BigDecimal afterDiscount = bill.getAmountAfterDiscount();
 		BigDecimal paid = bill.getTotalPayments();
-		BigDecimal balance = afterDiscount.subtract(paid);
 		
 		StringBuilder text = new StringBuilder("Bill");
 		String receipt = trimToNull(bill.getReceiptNumber());
@@ -106,11 +111,7 @@ public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 		if (!services.isEmpty()) {
 			text.append(". Services billed: ").append(String.join(", ", services));
 		}
-		text.append(". Total: ").append(money(total));
-		if (afterDiscount.compareTo(total) != 0) {
-			text.append(" (after discount ").append(money(afterDiscount)).append(')');
-		}
-		text.append(", paid: ").append(money(paid)).append(", balance: ").append(money(balance));
+		text.append(". Total: ").append(money(total)).append(", paid: ").append(money(paid));
 		String cashPoint = bill.getCashPoint() != null ? trimToNull(bill.getCashPoint().getName()) : null;
 		if (cashPoint != null) {
 			text.append(". Cash point: ").append(cashPoint);
@@ -119,39 +120,39 @@ public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 		doc.setText(text.toString());
 		
 		if (bill.getStatus() != null) {
-			doc.putMetadata(FIELD_BILL_STATUS, bill.getStatus().name());
+			doc.putMetadata(BillingQueryFields.BILL_STATUS, bill.getStatus().name());
 		}
 		if (receipt != null) {
-			doc.putMetadata(FIELD_RECEIPT_NUMBER, receipt);
+			doc.putMetadata(BillingQueryFields.RECEIPT_NUMBER, receipt);
 		}
-		doc.putMetadata(FIELD_TOTAL, money(afterDiscount));
-		doc.putMetadata(FIELD_AMOUNT_PAID, money(paid));
-		doc.putMetadata(FIELD_BALANCE, money(balance));
+		doc.putMetadata(BillingQueryFields.TOTAL, money(total));
+		doc.putMetadata(BillingQueryFields.AMOUNT_PAID, money(paid));
 		if (cashPoint != null) {
-			doc.putMetadata(FIELD_CASH_POINT, cashPoint);
+			doc.putMetadata(BillingQueryFields.CASH_POINT, cashPoint);
 		}
 		if (bill.getVisit() != null) {
 			doc.putMetadata(FIELD_VISIT_UUID, bill.getVisit().getUuid());
 		}
 		if (!services.isEmpty()) {
-			doc.putMetadata(FIELD_SERVICES, services);
-			doc.putMetadata(FIELD_LINE_ITEM_COUNT, services.size());
+			doc.putMetadata(BillingQueryFields.SERVICES, services);
+			doc.putMetadata(BillingQueryFields.BILLED_SERVICE_COUNT, services.size());
 		}
 		List<String> modes = paymentModes(bill);
 		if (!modes.isEmpty()) {
-			doc.putMetadata(FIELD_PAYMENT_MODES, modes);
+			doc.putMetadata(BillingQueryFields.PAYMENT_MODES, modes);
 		}
 	}
 	
 	/**
-	 * Human-readable label for each non-voided line item, preferring the billable service name and
+	 * Label for each non-voided line item (one entry per line item - not de-duplicated, since two line
+	 * items for the same service are two distinct charges), preferring the billable service name and
 	 * falling back to the stock item (dispensed drug / supply) or the price name.
 	 */
 	private static List<String> billedItemLabels(Bill bill) {
-		List<String> labels = new ArrayList<String>();
 		if (bill.getLineItems() == null) {
-			return labels;
+			return Collections.emptyList();
 		}
+		List<String> labels = new ArrayList<String>();
 		for (BillLineItem item : bill.getLineItems()) {
 			if (item == null || Boolean.TRUE.equals(item.getVoided())) {
 				continue;
@@ -192,22 +193,23 @@ public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 		return trimToNull(item.getPriceName());
 	}
 	
+	/** Distinct payment-mode names across the bill's non-voided payments. */
 	private static List<String> paymentModes(Bill bill) {
-		List<String> modes = new ArrayList<String>();
 		if (bill.getPayments() == null) {
-			return modes;
+			return Collections.emptyList();
 		}
+		Set<String> modes = new LinkedHashSet<String>();
 		for (Payment payment : bill.getPayments()) {
 			if (payment == null || Boolean.TRUE.equals(payment.getVoided())) {
 				continue;
 			}
 			if (payment.getInstanceType() != null) {
 				String name = trimToNull(payment.getInstanceType().getName());
-				if (name != null && !modes.contains(name)) {
+				if (name != null) {
 					modes.add(name);
 				}
 			}
 		}
-		return modes;
+		return new ArrayList<String>(modes);
 	}
 }

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRecordSerializer.java
@@ -158,13 +158,12 @@ public class BillRecordSerializer extends AbstractRecordSerializer<Bill> {
 				continue;
 			}
 			String label = labelFor(item);
-			if (label == null) {
-				continue;
+			if (label != null) {
+				if (item.getQuantity() != null && item.getQuantity() != 1) {
+					label = label + " (x" + item.getQuantity() + ")";
+				}
+				labels.add(label);
 			}
-			if (item.getQuantity() != null && item.getQuantity() != 1) {
-				label = label + " (x" + item.getQuantity() + ")";
-			}
-			labels.add(label);
 		}
 		return labels;
 	}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
+import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
+
+import java.time.LocalDate;
+
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillRefund;
+import org.openmrs.module.querystore.model.QueryDocument;
+import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
+import org.openmrs.module.querystore.util.DateFormatUtil;
+
+/**
+ * Serializes a {@link BillRefund} into a {@code billing_refund} document. Refunds are the weakest
+ * clinical signal of the three billing types (mostly administrative), but they complete the record
+ * and are indexed as their own type because their lifecycle (REQUESTED -> APPROVED -> COMPLETED)
+ * runs through the dedicated {@code saveBillRefund} service, whose save events keep the projection
+ * current.
+ */
+public class BillRefundRecordSerializer extends AbstractRecordSerializer<BillRefund> {
+	
+	public static final String RESOURCE_TYPE = "billing_refund";
+	
+	@Override
+	public String getResourceType() {
+		return RESOURCE_TYPE;
+	}
+	
+	@Override
+	public Class<BillRefund> getSupportedType() {
+		return BillRefund.class;
+	}
+	
+	@Override
+	protected String getPatientUuid(BillRefund refund) {
+		Bill bill = refund.getBill();
+		if (bill == null || bill.getPatient() == null) {
+			return null;
+		}
+		return bill.getPatient().getUuid();
+	}
+	
+	@Override
+	protected String getResourceUuid(BillRefund refund) {
+		return refund.getUuid();
+	}
+	
+	@Override
+	protected LocalDate getDate(BillRefund refund) {
+		return refund.getDateCreated() != null ? DateFormatUtil.toLocalDate(refund.getDateCreated()) : null;
+	}
+	
+	@Override
+	protected void populate(BillRefund refund, QueryDocument doc) {
+		Bill bill = refund.getBill();
+		String receipt = bill != null ? trimToNull(bill.getReceiptNumber()) : null;
+		
+		StringBuilder text = new StringBuilder("Bill refund");
+		if (receipt != null) {
+			text.append(" on bill ").append(receipt);
+		}
+		text.append(": amount ").append(money(refund.getRefundAmount()));
+		if (refund.getStatus() != null) {
+			text.append(". Status: ").append(readable(refund.getStatus().name()));
+		}
+		String reason = trimToNull(refund.getReason());
+		if (reason != null) {
+			text.append(". Reason: ").append(reason);
+		}
+		text.append('.');
+		doc.setText(text.toString());
+		
+		if (refund.getStatus() != null) {
+			doc.putMetadata("refund_status", refund.getStatus().name());
+		}
+		doc.putMetadata("refund_amount", money(refund.getRefundAmount()));
+		if (bill != null && bill.getUuid() != null) {
+			doc.putMetadata("bill_uuid", bill.getUuid());
+		}
+		if (receipt != null) {
+			doc.putMetadata("receipt_number", receipt);
+		}
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
@@ -11,15 +11,10 @@ package org.openmrs.module.billing.querystore.serialization;
 
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.money;
 import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.readable;
-import static org.openmrs.module.billing.querystore.serialization.BillDocFormat.trimToNull;
-
-import java.time.LocalDate;
 
 import org.openmrs.module.billing.api.model.Bill;
 import org.openmrs.module.billing.api.model.BillRefund;
 import org.openmrs.module.querystore.model.QueryDocument;
-import org.openmrs.module.querystore.serialization.AbstractRecordSerializer;
-import org.openmrs.module.querystore.util.DateFormatUtil;
 
 /**
  * Serializes a {@link BillRefund} into a {@code billing_refund} document. Refunds are the weakest
@@ -28,7 +23,7 @@ import org.openmrs.module.querystore.util.DateFormatUtil;
  * runs through the dedicated {@code saveBillRefund} service, whose save events keep the projection
  * current.
  */
-public class BillRefundRecordSerializer extends AbstractRecordSerializer<BillRefund> {
+public class BillRefundRecordSerializer extends AbstractBillChildRecordSerializer<BillRefund> {
 	
 	public static final String RESOURCE_TYPE = "billing_refund";
 	
@@ -43,28 +38,17 @@ public class BillRefundRecordSerializer extends AbstractRecordSerializer<BillRef
 	}
 	
 	@Override
-	protected String getPatientUuid(BillRefund refund) {
-		Bill bill = refund.getBill();
-		if (bill == null || bill.getPatient() == null) {
-			return null;
-		}
-		return bill.getPatient().getUuid();
-	}
-	
-	@Override
-	protected String getResourceUuid(BillRefund refund) {
-		return refund.getUuid();
-	}
-	
-	@Override
-	protected LocalDate getDate(BillRefund refund) {
-		return refund.getDateCreated() != null ? DateFormatUtil.toLocalDate(refund.getDateCreated()) : null;
+	protected Bill billOf(BillRefund refund) {
+		return refund.getBill();
 	}
 	
 	@Override
 	protected void populate(BillRefund refund, QueryDocument doc) {
+		if (doc.getPatientUuid() == null) {
+			return; // no patient scope (unreachable: bill/patient are NOT NULL FKs) - skip, matching backfill
+		}
 		Bill bill = refund.getBill();
-		String receipt = bill != null ? trimToNull(bill.getReceiptNumber()) : null;
+		String receipt = receiptOf(bill);
 		
 		StringBuilder text = new StringBuilder("Bill refund");
 		if (receipt != null) {
@@ -82,14 +66,9 @@ public class BillRefundRecordSerializer extends AbstractRecordSerializer<BillRef
 		doc.setText(text.toString());
 		
 		if (refund.getStatus() != null) {
-			doc.putMetadata("refund_status", refund.getStatus().name());
+			doc.putMetadata(BillingQueryFields.REFUND_STATUS, refund.getStatus().name());
 		}
-		doc.putMetadata("refund_amount", money(refund.getRefundAmount()));
-		if (bill != null && bill.getUuid() != null) {
-			doc.putMetadata("bill_uuid", bill.getUuid());
-		}
-		if (receipt != null) {
-			doc.putMetadata("receipt_number", receipt);
-		}
+		doc.putMetadata(BillingQueryFields.REFUND_AMOUNT, money(refund.getRefundAmount()));
+		putBillReference(doc, bill, receipt);
 	}
 }

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillRefundRecordSerializer.java
@@ -20,8 +20,10 @@ import org.openmrs.module.querystore.model.QueryDocument;
  * Serializes a {@link BillRefund} into a {@code billing_refund} document. Refunds are the weakest
  * clinical signal of the three billing types (mostly administrative), but they complete the record
  * and are indexed as their own type because their lifecycle (REQUESTED -> APPROVED -> COMPLETED)
- * runs through the dedicated {@code saveBillRefund} service, whose save events keep the projection
- * current.
+ * changes independently of the bill. {@code BillRefundService} is not an {@code OpenmrsService}, so
+ * live-sync is handled by {@link org.openmrs.module.billing.querystore.BillChildDbEventListener}
+ * (core's non-AOP Hibernate {@code SaveDbEvent}), not #6084 service events; initial backfill is by
+ * {@code BillRefundBootstrapper}.
  */
 public class BillRefundRecordSerializer extends AbstractBillChildRecordSerializer<BillRefund> {
 	

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillingQueryFields.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/serialization/BillingQueryFields.java
@@ -1,0 +1,59 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+/**
+ * Single source of truth for the billing-specific {@code metadata} field names written to
+ * {@link org.openmrs.module.querystore.model.QueryDocument}. Keeping them here (rather than as raw
+ * literals scattered across the serializers) stops the shared keys - {@link #RECEIPT_NUMBER},
+ * {@link #BILL_UUID} - from drifting between the bill, discount and refund documents.
+ * <p>
+ * Cross-cutting field names that querystore itself defines (e.g. {@code visit_uuid}) are taken from
+ * {@code QueryStoreConstants}, not redefined here.
+ */
+final class BillingQueryFields {
+	
+	private BillingQueryFields() {
+	}
+	
+	// Shared across bill / discount / refund documents.
+	static final String RECEIPT_NUMBER = "receipt_number";
+	
+	static final String BILL_UUID = "bill_uuid";
+	
+	// billing_bill
+	static final String BILL_STATUS = "bill_status";
+	
+	static final String TOTAL = "total";
+	
+	static final String AMOUNT_PAID = "amount_paid";
+	
+	static final String CASH_POINT = "cash_point";
+	
+	static final String SERVICES = "services";
+	
+	static final String PAYMENT_MODES = "payment_modes";
+	
+	static final String BILLED_SERVICE_COUNT = "billed_service_count";
+	
+	// billing_discount
+	static final String DISCOUNT_STATUS = "discount_status";
+	
+	static final String DISCOUNT_TYPE = "discount_type";
+	
+	static final String DISCOUNT_PERCENT = "discount_percent";
+	
+	static final String DISCOUNT_AMOUNT = "discount_amount";
+	
+	// billing_refund
+	static final String REFUND_STATUS = "refund_status";
+	
+	static final String REFUND_AMOUNT = "refund_amount";
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillDiscountProvider.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillDiscountProvider.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.spi;
+
+import org.openmrs.module.billing.querystore.bootstrap.BillDiscountBootstrapper;
+import org.openmrs.module.billing.querystore.serialization.BillDiscountRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.TypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+import org.openmrs.module.querystore.spi.ResourceTypeProvider;
+
+/**
+ * Registers the {@code billing_discount} resource type with the query store.
+ */
+public class BillDiscountProvider implements ResourceTypeProvider {
+	
+	private final BillDiscountRecordSerializer serializer;
+	
+	private final BillDiscountBootstrapper bootstrapper;
+	
+	public BillDiscountProvider(BillDiscountRecordSerializer serializer, BillDiscountBootstrapper bootstrapper) {
+		this.serializer = serializer;
+		this.bootstrapper = bootstrapper;
+	}
+	
+	@Override
+	public String getResourceType() {
+		return BillDiscountRecordSerializer.RESOURCE_TYPE;
+	}
+	
+	@Override
+	public ClinicalRecordSerializer<?> getSerializer() {
+		return serializer;
+	}
+	
+	@Override
+	public TypeBootstrapper<?> getBootstrapper() {
+		return bootstrapper;
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillProvider.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillProvider.java
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.spi;
+
+import org.openmrs.module.billing.querystore.bootstrap.BillBootstrapper;
+import org.openmrs.module.billing.querystore.serialization.BillRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.TypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+import org.openmrs.module.querystore.spi.ResourceTypeProvider;
+
+/**
+ * Registers the {@code billing_bill} resource type with the query store. Discovered by querystore
+ * via {@code Context.getRegisteredComponents(ResourceTypeProvider.class)}.
+ */
+public class BillProvider implements ResourceTypeProvider {
+	
+	private final BillRecordSerializer serializer;
+	
+	private final BillBootstrapper bootstrapper;
+	
+	public BillProvider(BillRecordSerializer serializer, BillBootstrapper bootstrapper) {
+		this.serializer = serializer;
+		this.bootstrapper = bootstrapper;
+	}
+	
+	@Override
+	public String getResourceType() {
+		return BillRecordSerializer.RESOURCE_TYPE;
+	}
+	
+	@Override
+	public ClinicalRecordSerializer<?> getSerializer() {
+		return serializer;
+	}
+	
+	@Override
+	public TypeBootstrapper<?> getBootstrapper() {
+		return bootstrapper;
+	}
+}

--- a/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillRefundProvider.java
+++ b/querystore/src/main/java/org/openmrs/module/billing/querystore/spi/BillRefundProvider.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.spi;
+
+import org.openmrs.module.billing.querystore.bootstrap.BillRefundBootstrapper;
+import org.openmrs.module.billing.querystore.serialization.BillRefundRecordSerializer;
+import org.openmrs.module.querystore.bootstrap.TypeBootstrapper;
+import org.openmrs.module.querystore.serialization.ClinicalRecordSerializer;
+import org.openmrs.module.querystore.spi.ResourceTypeProvider;
+
+/**
+ * Registers the {@code billing_refund} resource type with the query store.
+ */
+public class BillRefundProvider implements ResourceTypeProvider {
+	
+	private final BillRefundRecordSerializer serializer;
+	
+	private final BillRefundBootstrapper bootstrapper;
+	
+	public BillRefundProvider(BillRefundRecordSerializer serializer, BillRefundBootstrapper bootstrapper) {
+		this.serializer = serializer;
+		this.bootstrapper = bootstrapper;
+	}
+	
+	@Override
+	public String getResourceType() {
+		return BillRefundRecordSerializer.RESOURCE_TYPE;
+	}
+	
+	@Override
+	public ClinicalRecordSerializer<?> getSerializer() {
+		return serializer;
+	}
+	
+	@Override
+	public TypeBootstrapper<?> getBootstrapper() {
+		return bootstrapper;
+	}
+}

--- a/querystore/src/main/resources/config.xml
+++ b/querystore/src/main/resources/config.xml
@@ -29,6 +29,9 @@
 	<require_modules>
 		<require_module version="2.4">org.openmrs.module.billing</require_module>
 		<require_module version="1.0">org.openmrs.module.querystore</require_module>
+		<!-- The bill serializer references StockItem/Drug for line items that bill a stock item;
+		     require stockmanagement (billing already does) so those classes resolve on our classloader. -->
+		<require_module version="1.4">org.openmrs.module.stockmanagement</require_module>
 	</require_modules>
 
 	<!-- Module Activator -->

--- a/querystore/src/main/resources/config.xml
+++ b/querystore/src/main/resources/config.xml
@@ -22,13 +22,20 @@
 		Projects billing records (bills, discounts, refunds) into the OpenMRS QueryStore so a
 		clinician-facing semantic/keyword chart search can retrieve them.
 	</description>
-	<!-- The core *ServiceEvent API this integration relies on (openmrs-core #6084) is 2.9-only. -->
-	<require_version>2.9.0</require_version>
+	<!-- The core *ServiceEvent API this integration relies on (openmrs-core #6084) is 2.9-only.
+	     Filtered to the built-against platform version (currently 2.9.0-SNAPSHOT); OpenMRS treats a
+	     bare "2.9.0" as newer than a running "2.9.0-SNAPSHOT", so requiring the exact version avoids
+	     a spurious platform-version rejection - same reason chartsearchai pins 2.9.0-SNAPSHOT. -->
+	<require_version>${openmrsPlatformVersion}</require_version>
 	<!-- / Module Properties -->
 
 	<require_modules>
-		<require_module version="2.4">org.openmrs.module.billing</require_module>
-		<require_module version="1.0">org.openmrs.module.querystore</require_module>
+		<!-- Match the exact (SNAPSHOT) dependency versions: OpenMRS ranks "X.Y.Z-SNAPSHOT" below a
+		     bare "X.Y.Z" required version, so a bare require would be left unsatisfied by the running
+		     SNAPSHOT builds. Filtered from this module's properties (= the sibling billing version and
+		     the querystore version we build against), matching chartsearchai's require of querystore. -->
+		<require_module version="${project.parent.version}">org.openmrs.module.billing</require_module>
+		<require_module version="${querystoreVersion}">org.openmrs.module.querystore</require_module>
 		<!-- The bill serializer references StockItem/Drug for line items that bill a stock item;
 		     require stockmanagement (billing already does) so those classes resolve on our classloader. -->
 		<require_module version="1.4">org.openmrs.module.stockmanagement</require_module>

--- a/querystore/src/main/resources/config.xml
+++ b/querystore/src/main/resources/config.xml
@@ -38,7 +38,7 @@
 		<require_module version="${querystoreVersion}">org.openmrs.module.querystore</require_module>
 		<!-- The bill serializer references StockItem/Drug for line items that bill a stock item;
 		     require stockmanagement (billing already does) so those classes resolve on our classloader. -->
-		<require_module version="1.4">org.openmrs.module.stockmanagement</require_module>
+		<require_module version="${stockmanagementVersion}">org.openmrs.module.stockmanagement</require_module>
 	</require_modules>
 
 	<!-- Module Activator -->

--- a/querystore/src/main/resources/config.xml
+++ b/querystore/src/main/resources/config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<module configVersion="1.2">
+
+	<!-- Module Properties -->
+	<id>billingquerystore</id>
+	<name>OpenMRS Billing Module QueryStore Integration</name>
+	<version>${project.parent.version}</version>
+	<package>org.openmrs.module.billing.querystore</package>
+	<author>OpenMRS</author>
+	<description>
+		Projects billing records (bills, discounts, refunds) into the OpenMRS QueryStore so a
+		clinician-facing semantic/keyword chart search can retrieve them.
+	</description>
+	<!-- The core *ServiceEvent API this integration relies on (openmrs-core #6084) is 2.9-only. -->
+	<require_version>2.9.0</require_version>
+	<!-- / Module Properties -->
+
+	<require_modules>
+		<require_module version="2.4">org.openmrs.module.billing</require_module>
+		<require_module version="1.0">org.openmrs.module.querystore</require_module>
+	</require_modules>
+
+	<!-- Module Activator -->
+	<activator>org.openmrs.module.billing.querystore.BillingQuerystoreActivator</activator>
+
+</module>

--- a/querystore/src/main/resources/moduleApplicationContext.xml
+++ b/querystore/src/main/resources/moduleApplicationContext.xml
@@ -71,4 +71,13 @@
 		<constructor-arg ref="billing.querystore.bootstrapper.refund"/>
 	</bean>
 
+	<!--
+		Live-sync for billing_discount / billing_refund. Their services are not OpenmrsServices, so
+		core #6084's AOP service-event advice never fires for them; instead we consume core's non-AOP
+		Hibernate SaveDbEvent/DeleteDbEvent (which fire for every entity) and drive the same querystore
+		projection pipeline. Bill itself is handled by querystore's own consumer via its SaveServiceEvent.
+	-->
+	<bean id="billing.querystore.dbEventListener"
+	      class="org.openmrs.module.billing.querystore.BillChildDbEventListener"/>
+
 </beans>

--- a/querystore/src/main/resources/moduleApplicationContext.xml
+++ b/querystore/src/main/resources/moduleApplicationContext.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<!--
+		Each billing resource type contributes three beans: a serializer (entity -> QueryDocument), a
+		bootstrapper (one-time backfill of existing rows), and a provider that bundles them and declares
+		the resource type name. querystore discovers the providers - and the serializers, which its
+		events consumer resolves per save - via Context.getRegisteredComponents(...). `dbSessionFactory`
+		is the core Hibernate session factory the bootstrappers page over.
+	-->
+
+	<!-- ============================ billing_bill ============================ -->
+	<bean id="billing.querystore.serializer.bill"
+	      class="org.openmrs.module.billing.querystore.serialization.BillRecordSerializer"/>
+
+	<bean id="billing.querystore.bootstrapper.bill"
+	      class="org.openmrs.module.billing.querystore.bootstrap.BillBootstrapper">
+		<constructor-arg ref="billing.querystore.serializer.bill"/>
+		<constructor-arg ref="dbSessionFactory"/>
+	</bean>
+
+	<bean id="billing.querystore.provider.bill"
+	      class="org.openmrs.module.billing.querystore.spi.BillProvider">
+		<constructor-arg ref="billing.querystore.serializer.bill"/>
+		<constructor-arg ref="billing.querystore.bootstrapper.bill"/>
+	</bean>
+
+	<!-- ========================== billing_discount ========================== -->
+	<bean id="billing.querystore.serializer.discount"
+	      class="org.openmrs.module.billing.querystore.serialization.BillDiscountRecordSerializer"/>
+
+	<bean id="billing.querystore.bootstrapper.discount"
+	      class="org.openmrs.module.billing.querystore.bootstrap.BillDiscountBootstrapper">
+		<constructor-arg ref="billing.querystore.serializer.discount"/>
+		<constructor-arg ref="dbSessionFactory"/>
+	</bean>
+
+	<bean id="billing.querystore.provider.discount"
+	      class="org.openmrs.module.billing.querystore.spi.BillDiscountProvider">
+		<constructor-arg ref="billing.querystore.serializer.discount"/>
+		<constructor-arg ref="billing.querystore.bootstrapper.discount"/>
+	</bean>
+
+	<!-- =========================== billing_refund =========================== -->
+	<bean id="billing.querystore.serializer.refund"
+	      class="org.openmrs.module.billing.querystore.serialization.BillRefundRecordSerializer"/>
+
+	<bean id="billing.querystore.bootstrapper.refund"
+	      class="org.openmrs.module.billing.querystore.bootstrap.BillRefundBootstrapper">
+		<constructor-arg ref="billing.querystore.serializer.refund"/>
+		<constructor-arg ref="dbSessionFactory"/>
+	</bean>
+
+	<bean id="billing.querystore.provider.refund"
+	      class="org.openmrs.module.billing.querystore.spi.BillRefundProvider">
+		<constructor-arg ref="billing.querystore.serializer.refund"/>
+		<constructor-arg ref="billing.querystore.bootstrapper.refund"/>
+	</bean>
+
+</beans>

--- a/querystore/src/test/java/org/openmrs/module/billing/querystore/serialization/BillingRecordSerializerTest.java
+++ b/querystore/src/test/java/org/openmrs/module/billing/querystore/serialization/BillingRecordSerializerTest.java
@@ -1,0 +1,202 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.querystore.serialization;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.billing.api.model.Bill;
+import org.openmrs.module.billing.api.model.BillDiscount;
+import org.openmrs.module.billing.api.model.BillLineItem;
+import org.openmrs.module.billing.api.model.BillRefund;
+import org.openmrs.module.billing.api.model.BillStatus;
+import org.openmrs.module.billing.api.model.BillableService;
+import org.openmrs.module.billing.api.model.CashPoint;
+import org.openmrs.module.billing.api.model.DiscountStatus;
+import org.openmrs.module.billing.api.model.DiscountType;
+import org.openmrs.module.billing.api.model.Payment;
+import org.openmrs.module.billing.api.model.PaymentMode;
+import org.openmrs.module.billing.api.model.RefundStatus;
+import org.openmrs.module.querystore.model.QueryDocument;
+
+public class BillingRecordSerializerTest {
+	
+	private final BillRecordSerializer billSerializer = new BillRecordSerializer();
+	
+	private final BillDiscountRecordSerializer discountSerializer = new BillDiscountRecordSerializer();
+	
+	private final BillRefundRecordSerializer refundSerializer = new BillRefundRecordSerializer();
+	
+	@Test
+	public void serialize_shouldProjectBillWithItemsPaymentAndStatus() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-uuid");
+		
+		Bill bill = new Bill();
+		bill.setUuid("bill-uuid");
+		bill.setPatient(patient);
+		bill.setReceiptNumber("RCT-1001");
+		bill.setStatus(BillStatus.PAID);
+		bill.setDateCreated(new Date());
+		bill.setCashPoint(cashPoint("OPD Cashier"));
+		bill.setLineItems(Arrays.asList(lineItem("Consultation", "100", 1), lineItem("Malaria RDT", "50", 2)));
+		bill.setPayments(cashPayment("200"));
+		
+		QueryDocument doc = billSerializer.serialize(bill);
+		
+		assertThat(doc, is(notNullValue()));
+		assertThat(doc.getResourceType(), is("billing_bill"));
+		assertThat(doc.getResourceUuid(), is("bill-uuid"));
+		assertThat(doc.getPatientUuid(), is("patient-uuid"));
+		// text leads with the clinically-useful billed items, then the payment picture
+		assertThat(doc.getText(), containsString("Consultation"));
+		assertThat(doc.getText(), containsString("Malaria RDT (x2)"));
+		assertThat(doc.getText(), containsString("Status: paid"));
+		assertThat(doc.getText(), containsString("Total: 200"));
+		assertThat(doc.getText(), containsString("balance: 0"));
+		assertThat(doc.getMetadata().get("bill_status"), is((Object) "PAID"));
+		assertThat(doc.getMetadata().get("balance"), is((Object) "0"));
+		assertThat(asStrings(doc.getMetadata().get("services")), hasItem("Consultation"));
+		assertThat(asStrings(doc.getMetadata().get("payment_modes")), hasItem("Cash"));
+	}
+	
+	@Test
+	public void serialize_shouldSkipVoidedLineItems() {
+		Bill bill = new Bill();
+		bill.setUuid("bill-uuid");
+		bill.setPatient(patient("patient-uuid"));
+		bill.setStatus(BillStatus.PENDING);
+		BillLineItem voided = lineItem("Voided service", "10", 1);
+		voided.setVoided(true);
+		bill.setLineItems(Arrays.asList(lineItem("Consultation", "100", 1), voided));
+		
+		QueryDocument doc = billSerializer.serialize(bill);
+		
+		assertThat(doc.getText(), containsString("Consultation"));
+		assertThat(doc.getText().contains("Voided service"), is(false));
+	}
+	
+	@Test
+	public void serialize_shouldProjectDiscountScopedToPatientViaBill() {
+		Bill bill = new Bill();
+		bill.setReceiptNumber("RCT-1001");
+		bill.setPatient(patient("patient-uuid"));
+		
+		BillDiscount discount = new BillDiscount();
+		discount.setUuid("discount-uuid");
+		discount.setBill(bill);
+		discount.setDiscountType(DiscountType.FIXED_AMOUNT);
+		discount.setDiscountValue(new BigDecimal("50"));
+		discount.setStatus(DiscountStatus.APPROVED);
+		discount.setJustification("Under-5 waiver");
+		discount.setDateCreated(new Date());
+		
+		QueryDocument doc = discountSerializer.serialize(discount);
+		
+		assertThat(doc, is(notNullValue()));
+		assertThat(doc.getResourceType(), is("billing_discount"));
+		assertThat(doc.getPatientUuid(), is("patient-uuid"));
+		assertThat(doc.getText(), containsString("Under-5 waiver"));
+		assertThat(doc.getText(), containsString("Status: approved"));
+		assertThat(doc.getMetadata().get("discount_status"), is((Object) "APPROVED"));
+	}
+	
+	@Test
+	public void serialize_shouldProjectRefundScopedToPatientViaBill() {
+		Bill bill = new Bill();
+		bill.setReceiptNumber("RCT-1001");
+		bill.setPatient(patient("patient-uuid"));
+		
+		BillRefund refund = new BillRefund();
+		refund.setUuid("refund-uuid");
+		refund.setBill(bill);
+		refund.setRefundAmount(new BigDecimal("120"));
+		refund.setStatus(RefundStatus.COMPLETED);
+		refund.setReason("Overcharge on lab test");
+		refund.setDateCreated(new Date());
+		
+		QueryDocument doc = refundSerializer.serialize(refund);
+		
+		assertThat(doc, is(notNullValue()));
+		assertThat(doc.getResourceType(), is("billing_refund"));
+		assertThat(doc.getPatientUuid(), is("patient-uuid"));
+		assertThat(doc.getText(), containsString("Overcharge on lab test"));
+		assertThat(doc.getText(), containsString("amount 120"));
+		assertThat(doc.getMetadata().get("refund_status"), is((Object) "COMPLETED"));
+	}
+	
+	@Test
+	public void serialize_shouldNotScopeDiscountWhenBillHasNoPatient() {
+		BillDiscount discount = new BillDiscount();
+		discount.setUuid("discount-uuid");
+		discount.setBill(new Bill());
+		discount.setDiscountType(DiscountType.FIXED_AMOUNT);
+		discount.setDiscountValue(new BigDecimal("50"));
+		discount.setStatus(DiscountStatus.PENDING);
+		discount.setDateCreated(new Date());
+		
+		QueryDocument doc = discountSerializer.serialize(discount);
+		
+		assertThat(doc.getPatientUuid(), is(nullValue()));
+	}
+	
+	private static Patient patient(String uuid) {
+		Patient patient = new Patient();
+		patient.setUuid(uuid);
+		return patient;
+	}
+	
+	private static CashPoint cashPoint(String name) {
+		CashPoint cashPoint = new CashPoint();
+		cashPoint.setName(name);
+		return cashPoint;
+	}
+	
+	private static BillLineItem lineItem(String serviceName, String price, int quantity) {
+		BillableService service = new BillableService();
+		service.setName(serviceName);
+		BillLineItem lineItem = new BillLineItem();
+		lineItem.setBillableService(service);
+		lineItem.setPrice(new BigDecimal(price));
+		lineItem.setQuantity(quantity);
+		lineItem.setVoided(false);
+		return lineItem;
+	}
+	
+	private static Set<Payment> cashPayment(String amountTendered) {
+		PaymentMode mode = new PaymentMode();
+		mode.setName("Cash");
+		Payment payment = new Payment();
+		payment.setInstanceType(mode);
+		payment.setAmountTendered(new BigDecimal(amountTendered));
+		payment.setVoided(false);
+		Set<Payment> payments = new HashSet<Payment>();
+		payments.add(payment);
+		return payments;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static List<String> asStrings(Object metadataValue) {
+		return (List<String>) metadataValue;
+	}
+}

--- a/querystore/src/test/java/org/openmrs/module/billing/querystore/serialization/BillingRecordSerializerTest.java
+++ b/querystore/src/test/java/org/openmrs/module/billing/querystore/serialization/BillingRecordSerializerTest.java
@@ -73,9 +73,10 @@ public class BillingRecordSerializerTest {
 		assertThat(doc.getText(), containsString("Malaria RDT (x2)"));
 		assertThat(doc.getText(), containsString("Status: paid"));
 		assertThat(doc.getText(), containsString("Total: 200"));
-		assertThat(doc.getText(), containsString("balance: 0"));
+		assertThat(doc.getText(), containsString("paid: 200"));
 		assertThat(doc.getMetadata().get("bill_status"), is((Object) "PAID"));
-		assertThat(doc.getMetadata().get("balance"), is((Object) "0"));
+		assertThat(doc.getMetadata().get("total"), is((Object) "200"));
+		assertThat(doc.getMetadata().get("amount_paid"), is((Object) "200"));
 		assertThat(asStrings(doc.getMetadata().get("services")), hasItem("Consultation"));
 		assertThat(asStrings(doc.getMetadata().get("payment_modes")), hasItem("Cash"));
 	}
@@ -146,7 +147,7 @@ public class BillingRecordSerializerTest {
 	}
 	
 	@Test
-	public void serialize_shouldNotScopeDiscountWhenBillHasNoPatient() {
+	public void serialize_shouldSkipDiscountWhenBillHasNoPatient() {
 		BillDiscount discount = new BillDiscount();
 		discount.setUuid("discount-uuid");
 		discount.setBill(new Bill());
@@ -157,7 +158,72 @@ public class BillingRecordSerializerTest {
 		
 		QueryDocument doc = discountSerializer.serialize(discount);
 		
-		assertThat(doc.getPatientUuid(), is(nullValue()));
+		// No patient scope -> no document at all (parity with the backfill scan's patient filter).
+		assertThat(doc, is(nullValue()));
+	}
+	
+	@Test
+	public void serialize_shouldUseRawTotalUnaffectedByApprovedDiscount() {
+		// billing_bill must not denormalize the discount-adjusted total: saveBillDiscount does not
+		// re-save the bill, so a folded after-discount figure would go stale. Assert we expose the
+		// raw line-item total even when an approved discount is present on the bill.
+		Bill bill = new Bill();
+		bill.setUuid("bill-uuid");
+		bill.setPatient(patient("patient-uuid"));
+		bill.setStatus(BillStatus.POSTED);
+		bill.setLineItems(Arrays.asList(lineItem("Consultation", "200", 1)));
+		BillDiscount approved = new BillDiscount();
+		approved.setBill(bill);
+		approved.setDiscountType(DiscountType.FIXED_AMOUNT);
+		approved.setDiscountValue(new BigDecimal("50"));
+		approved.setStatus(DiscountStatus.APPROVED);
+		approved.setVoided(false);
+		Set<BillDiscount> discounts = new HashSet<BillDiscount>();
+		discounts.add(approved);
+		bill.setDiscounts(discounts);
+		
+		QueryDocument doc = billSerializer.serialize(bill);
+		
+		assertThat(doc.getMetadata().get("total"), is((Object) "200"));
+		assertThat(doc.getText(), containsString("Total: 200"));
+	}
+	
+	@Test
+	public void serialize_shouldProjectBillWithNoLineItems() {
+		Bill bill = new Bill();
+		bill.setUuid("bill-uuid");
+		bill.setPatient(patient("patient-uuid"));
+		bill.setStatus(BillStatus.PENDING);
+		
+		QueryDocument doc = billSerializer.serialize(bill);
+		
+		assertThat(doc, is(notNullValue()));
+		assertThat(doc.getText(), containsString("Total: 0"));
+		assertThat(doc.getMetadata().get("services"), is(nullValue()));
+		assertThat(doc.getMetadata().get("billed_service_count"), is(nullValue()));
+	}
+	
+	@Test
+	public void serialize_shouldExposeDiscountPercentForPercentageDiscount() {
+		Bill bill = new Bill();
+		bill.setReceiptNumber("RCT-1001");
+		bill.setPatient(patient("patient-uuid"));
+		bill.setLineItems(Arrays.asList(lineItem("Consultation", "200", 1)));
+		
+		BillDiscount discount = new BillDiscount();
+		discount.setUuid("discount-uuid");
+		discount.setBill(bill);
+		discount.setDiscountType(DiscountType.PERCENTAGE);
+		discount.setDiscountValue(new BigDecimal("10"));
+		discount.setStatus(DiscountStatus.APPROVED);
+		discount.setDateCreated(new Date());
+		
+		QueryDocument doc = discountSerializer.serialize(discount);
+		
+		assertThat(doc.getMetadata().get("discount_percent"), is((Object) "10"));
+		// discount_amount is always the resolved currency amount: 10% of the 200 bill total = 20.00
+		assertThat(doc.getMetadata().get("discount_amount"), is((Object) "20.00"));
+		assertThat(doc.getMetadata().get("discount_type"), is((Object) "PERCENTAGE"));
 	}
 	
 	private static Patient patient(String uuid) {


### PR DESCRIPTION
## What

Lets the billing module contribute its patient records to the [OpenMRS QueryStore](https://github.com/openmrs/openmrs-module-querystore) so a clinician-facing semantic / keyword chart search (e.g. `chartsearchai`) can retrieve them. Ships as a new, **optional** `billing-querystore` omod.

> 📐 The architectural decisions behind this PR are recorded in [`docs/adr.md`](https://github.com/openmrs/openmrs-module-billing/blob/querystore-integration/docs/adr.md).

## The key realization

The QueryStore integration path is **"register a serializer," not "publish events."** QueryStore's steady‑state sync (`CoreServiceEventListener`) consumes the `*ServiceEvent`s that core [openmrs-core#6084](https://github.com/openmrs/openmrs-core/pull/6084) (TRUNK‑6429, merged to `2.9.x`) publishes for **every** `OpenmrsService` method named `save*` / `void*` / `unvoid*` / `retire*` / `unretire*` / `purge*` whose first arg is an `OpenmrsObject`, and projects any entity for which a `ClinicalRecordSerializer` is registered.

That covers **`billing_bill`** (its `BillService` is an `OpenmrsService`). `BillDiscountService` / `BillRefundService` are plain interfaces, so #6084's *service*-event advice never fires for them — **`billing_discount` / `billing_refund` live-sync instead through a small `BillChildDbEventListener`** in this submodule that consumes core's other, **non-AOP** half: the Hibernate `EventInterceptor`'s `SaveDbEvent` / `DeleteDbEvent`, which fire for every persisted entity. No base-billing change; all three types were verified live on a 2.9 standalone (see verification comments).

Billing's services already fit that shape — `saveBill` / `voidBill` / `unvoidBill` / `purgeBill`, `saveBillDiscount`, `saveBillRefund` — and are wired the standard OpenMRS way (`TransactionProxyFactoryBean` + core `serviceInterceptors`). So **live indexing comes for free once a serializer is registered**; the base billing services are not touched.

## What gets indexed — the "useful to a clinician reading the chart" lens

Three patient‑scoped resource types (all `BaseOpenmrsData`, each with its own `save*` events):

| Resource type | Why a clinician cares |
|---|---|
| **`billing_bill`** | The anchor. Its text folds in the billed **services / drugs / tests** (line items), the raw total, amount paid, status and cash point — i.e. what care the patient was charged for. (The discount-adjusted balance is intentionally **not** folded in — see Hardening below.) |
| **`billing_discount`** | Fee waivers / discounts — often a marker of a subsidized programme (HIV, TB, under‑5, indigent) or financial hardship. |
| **`billing_refund`** | Refunds — weakest clinical signal, but completes the record and is nearly free to add. |

**Folded into `billing_bill`** (they cascade with the bill and have no independent save events): line items, payments. **Excluded** (not patient‑scoped or pure config, and QueryStore only projects `OpenmrsData` anyway): timesheets, cash points, payment modes, billable‑service catalog, item prices, exemption *rules*, sequence models.

## How it's built

- New `querystore/` submodule → per type a `ClinicalRecordSerializer` (`AbstractRecordSerializer` subclass), a `HibernateTypeBootstrapper` (backfill), and a `ResourceTypeProvider` (discovered by QueryStore via `Context.getRegisteredComponents`).
- Discount/refund bootstrappers scope through the parent bill (`e.bill.patient.uuid`) and cursor on `e.dateCreated` (they're JPA `@Entity`s that don't map `dateChanged`).
- Backfill of pre‑existing records is admin‑triggered (`POST /ws/rest/v1/querystore/reindex {"scope":"all"}` or `BootstrapService`), not run on startup.

## Why it's a separate, optional omod

QueryStore + the `#6084` event API require the (currently unreleased) **platform 2.9** plus an Elasticsearch/Lucene/ONNX backend. Baking that into the base module would force every billing deployment onto 2.9 + QueryStore. Instead this is a standalone `billing-querystore` omod, built only behind a Maven profile:

```bash
mvn -Pquerystore clean install
# → querystore/target/billing-querystore-*.omod  (install alongside billing only where QueryStore runs)
```

The default build, `pom.xml` `<modules>`, and the base `billing.omod` are unchanged and still target **2.7.8**. The only edits outside `querystore/` are the profile in the root `pom.xml` and a README section.

## Verification

- ✅ Compiles against `querystore-api:1.0.0-SNAPSHOT` + `openmrs-api:2.9.0-SNAPSHOT`.
- ✅ 8 serializer unit tests pass (bill with items/payments/status, voided‑item skipping, discount & refund patient‑scoping via the bill, patient‑less skip, discount‑independent raw total, percentage discount, empty‑line‑items).
- ✅ `billing-querystore-*.omod` packages.
- ✅ **Verified live on a 2.9 standalone** — [full results in this comment](https://github.com/openmrs/openmrs-module-billing/pull/186#issuecomment-4884120540). A bill created via `saveBill` with **no manual reindex** is projected by core #6084 into a `billing_bill` document and returned by a `chartsearchai` chart search within ~25s; the bootstrapper backfill path works too. So the `#6084`-for-free path **does** hold for this module's service (the `isAopProxy` / parent-child-context concern doesn't block it), and the fallback publisher aspect is **not** needed.

## Hardening (second commit)

An iterative review/polish pass tightened the slice by tracing its integration boundaries:

- **Discount‑balance staleness (correctness).** `BillDiscountService.saveBillDiscount` persists the discount alone and does **not** re‑save the parent bill, so a `billing_bill` document that folded in an "amount after discount" / outstanding balance would silently overstate what the patient owes until the bill's next save. `billing_bill` now exposes only bill‑aggregate‑derived fields that are refreshed on every `saveBill` (raw total, amount paid, status); discount detail lives on `billing_discount`. (`saveBillRefund`, by contrast, *does* reconcile + re‑save the bill, so refunds stay fresh.)
- **Classloader (integration).** The bill serializer references `StockItem`/`Drug`, so `stockmanagement` was added to `require_modules` — transitive visibility through `billing` isn't guaranteed.
- **Live/backfill parity.** Patient‑less records are now skipped on the live path too (they were already filtered by the backfill's `patient IS NOT NULL` scan). Unreachable for persisted entities (NOT‑NULL FKs), but keeps the two paths symmetric.
- **Metadata clarity.** `discount_value` (which conflated a percentage with a currency amount under one key) became `discount_percent` + an always‑currency `discount_amount`; `line_item_count` → `billed_service_count` (it counts billed‑service labels, not raw line items).
- **Polish.** Extracted `AbstractBillChildRecordSerializer` for the discount/refund shared logic, centralized metadata keys in `BillingQueryFields`, and reused the SPI's `trimToNull` / `QueryStoreConstants.FIELD_VISIT_UUID` instead of re‑implementing them.

Verified as non‑issues along the way: the bootstrapper HQL is valid for the JPA `@Entity` children (`BaseOpenmrsData` is a `@MappedSuperclass`), and discount/refund status updates re‑index correctly even without a `dateChanged` bump because querystore's upsert freshness guard is `>=`.

## Follow‑ups

- Verified live end-to-end on a 2.9 + QueryStore (Lucene) + chartsearchai standalone (see verification comments): all three types live-sync **and** backfill — `billing_bill` via core #6084 `SaveServiceEvent`, and `billing_discount` / `billing_refund` via the `SaveDbEvent` listener. Elasticsearch backend not exercised (Lucene is what's deployed; the serializers are backend-agnostic).
- Optionally tune `billing_bill` text once we see real chart‑search queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
