### PR TITLE
Add Codecov job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
     permissions:
       contents: read
-      id-token: write
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,15 @@
+name: Upload Coverage
+
+on:
+  workflow_run:
+    workflows: ["Build with Maven"]  # must match the build workflow's name:
+    types: [completed]
+
+jobs:
+  upload:
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      pull-requests: read
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/upload-coverage.yml@main


### PR DESCRIPTION
This is intended to make codecov continue working after openmrs-contrib-gha-workflows#47 is merged