### PR TITLE
feat: add date range filter parameters (startDate, endDate) to bill search api

### DIFF
--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
@@ -50,6 +50,8 @@ public class HibernateBillDAO implements BillDAO {
 	
 	private static final String FIELD_VOIDED = "voided";
 	
+	private static final String FIELD_DATE_CREATED = "dateCreated";
+	
 	@Setter(AccessLevel.PROTECTED)
 	private SessionFactory sessionFactory;
 	
@@ -96,7 +98,7 @@ public class HibernateBillDAO implements BillDAO {
 		
 		Predicate predicate = cb.equal(root.get("patient").get("uuid"), patientUuid);
 		cq.where(predicate);
-		cq.orderBy(cb.desc(root.get("dateCreated")));
+		cq.orderBy(cb.desc(root.get(FIELD_DATE_CREATED)));
 		
 		TypedQuery<Bill> query = session.createQuery(cq);
 		
@@ -123,7 +125,7 @@ public class HibernateBillDAO implements BillDAO {
 		if (!predicates.isEmpty()) {
 			cq.where(predicates.toArray(new Predicate[0]));
 		}
-		cq.orderBy(cb.desc(root.get("dateCreated")));
+		cq.orderBy(cb.desc(root.get(FIELD_DATE_CREATED)));
 		
 		TypedQuery<Bill> query = session.createQuery(cq);
 		
@@ -200,11 +202,11 @@ public class HibernateBillDAO implements BillDAO {
 		}
 		
 		if (billSearch.getStartDate() != null) {
-			predicates.add(cb.greaterThanOrEqualTo(root.get("dateCreated"), billSearch.getStartDate()));
+			predicates.add(cb.greaterThanOrEqualTo(root.get(FIELD_DATE_CREATED), billSearch.getStartDate()));
 		}
 		
 		if (billSearch.getEndDate() != null) {
-			predicates.add(cb.lessThanOrEqualTo(root.get("dateCreated"), billSearch.getEndDate()));
+			predicates.add(cb.lessThanOrEqualTo(root.get(FIELD_DATE_CREATED), billSearch.getEndDate()));
 		}
 		
 		return predicates;

--- a/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/db/hibernate/HibernateBillDAO.java
@@ -199,6 +199,14 @@ public class HibernateBillDAO implements BillDAO {
 			predicates.add(cb.exists(sub));
 		}
 		
+		if (billSearch.getStartDate() != null) {
+			predicates.add(cb.greaterThanOrEqualTo(root.get("dateCreated"), billSearch.getStartDate()));
+		}
+		
+		if (billSearch.getEndDate() != null) {
+			predicates.add(cb.lessThanOrEqualTo(root.get("dateCreated"), billSearch.getEndDate()));
+		}
+		
 		return predicates;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/search/BillSearch.java
@@ -48,6 +48,10 @@ public class BillSearch {
 	
 	private String patientName;
 	
+	private java.util.Date startDate;
+	
+	private java.util.Date endDate;
+	
 	private Boolean includeVoided = false;
 	
 	private Boolean includeVoidedLineItems = false;

--- a/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
@@ -439,6 +439,98 @@ public class HibernateBillDAOTest extends BaseModuleContextSensitiveTest {
 		    "Bill 2005 has only a voided REQUESTED refund — must be excluded even in multi-status query");
 	}
 	
+	@Test
+	public void getBills_shouldFilterByStartDate() {
+		Date now = new Date();
+		Patient patient = patientService.getPatient(0);
+		
+		Bill olderBill = new Bill();
+		olderBill.setCashier(providerService.getProvider(0));
+		olderBill.setPatient(patient);
+		olderBill.setCashPoint(cashPointService.getCashPoint(0));
+		olderBill.setReceiptNumber("START-DATE-OLD-" + UUID.randomUUID());
+		olderBill.setStatus(BillStatus.PENDING);
+		olderBill.setDateCreated(new Date(now.getTime() - 1000000));
+		billDAO.saveBill(olderBill);
+		
+		Bill newerBill = new Bill();
+		newerBill.setCashier(providerService.getProvider(0));
+		newerBill.setPatient(patient);
+		newerBill.setCashPoint(cashPointService.getCashPoint(0));
+		newerBill.setReceiptNumber("START-DATE-NEW-" + UUID.randomUUID());
+		newerBill.setStatus(BillStatus.PENDING);
+		newerBill.setDateCreated(new Date(now.getTime() + 1000000));
+		billDAO.saveBill(newerBill);
+		
+		Context.flushSession();
+		
+		BillSearch search = BillSearch.builder().startDate(new Date(now.getTime() + 500000)).build();
+		List<Bill> results = billDAO.getBills(search, null);
+		List<String> resultUuids = uuids(results);
+		
+		assertTrue(resultUuids.contains(newerBill.getUuid()));
+		assertFalse(resultUuids.contains(olderBill.getUuid()));
+	}
+	
+	@Test
+	public void getBills_shouldFilterByEndDate() {
+		Date now = new Date();
+		Patient patient = patientService.getPatient(0);
+		
+		Bill olderBill = new Bill();
+		olderBill.setCashier(providerService.getProvider(0));
+		olderBill.setPatient(patient);
+		olderBill.setCashPoint(cashPointService.getCashPoint(0));
+		olderBill.setReceiptNumber("END-DATE-OLD-" + UUID.randomUUID());
+		olderBill.setStatus(BillStatus.PENDING);
+		olderBill.setDateCreated(new Date(now.getTime() - 1000000));
+		billDAO.saveBill(olderBill);
+		
+		Bill newerBill = new Bill();
+		newerBill.setCashier(providerService.getProvider(0));
+		newerBill.setPatient(patient);
+		newerBill.setCashPoint(cashPointService.getCashPoint(0));
+		newerBill.setReceiptNumber("END-DATE-NEW-" + UUID.randomUUID());
+		newerBill.setStatus(BillStatus.PENDING);
+		newerBill.setDateCreated(new Date(now.getTime() + 1000000));
+		billDAO.saveBill(newerBill);
+		
+		Context.flushSession();
+		
+		BillSearch search = BillSearch.builder().endDate(new Date(now.getTime() - 500000)).build();
+		List<Bill> results = billDAO.getBills(search, null);
+		List<String> resultUuids = uuids(results);
+		
+		assertTrue(resultUuids.contains(olderBill.getUuid()));
+		assertFalse(resultUuids.contains(newerBill.getUuid()));
+	}
+	
+	@Test
+	public void getBills_shouldFilterByDateRange() {
+		Date now = new Date();
+		Patient patient = patientService.getPatient(0);
+		
+		Bill targetBill = new Bill();
+		targetBill.setCashier(providerService.getProvider(0));
+		targetBill.setPatient(patient);
+		targetBill.setCashPoint(cashPointService.getCashPoint(0));
+		targetBill.setReceiptNumber("RANGE-TARGET-" + UUID.randomUUID());
+		targetBill.setStatus(BillStatus.PENDING);
+		targetBill.setDateCreated(now);
+		billDAO.saveBill(targetBill);
+		
+		Context.flushSession();
+		
+		BillSearch search = BillSearch.builder()
+		        .startDate(new Date(now.getTime() - 10000))
+		        .endDate(new Date(now.getTime() + 10000))
+		        .build();
+		List<Bill> results = billDAO.getBills(search, null);
+		List<String> resultUuids = uuids(results);
+		
+		assertTrue(resultUuids.contains(targetBill.getUuid()));
+	}
+	
 	private List<String> uuids(List<Bill> bills) {
 		return bills.stream().map(Bill::getUuid).sorted().collect(Collectors.toList());
 	}

--- a/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/db/HibernateBillDAOTest.java
@@ -521,10 +521,8 @@ public class HibernateBillDAOTest extends BaseModuleContextSensitiveTest {
 		
 		Context.flushSession();
 		
-		BillSearch search = BillSearch.builder()
-		        .startDate(new Date(now.getTime() - 10000))
-		        .endDate(new Date(now.getTime() + 10000))
-		        .build();
+		BillSearch search = BillSearch.builder().startDate(new Date(now.getTime() - 10000))
+		        .endDate(new Date(now.getTime() + 10000)).build();
 		List<Bill> results = billDAO.getBills(search, null);
 		List<String> resultUuids = uuids(results);
 		

--- a/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/billing/web/rest/resource/BillResource.java
@@ -11,6 +11,7 @@ package org.openmrs.module.billing.web.rest.resource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +45,7 @@ import org.openmrs.module.billing.api.util.RoundingUtil;
 import org.openmrs.module.billing.web.base.resource.BaseRestDataResource;
 import org.openmrs.module.billing.web.base.resource.PagingUtil;
 import org.openmrs.module.billing.web.rest.controller.base.CashierResourceController;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -369,6 +371,16 @@ public class BillResource extends DataDelegatingCrudResource<Bill> {
 		String includeAll = context.getRequest().getParameter("includeAll");
 		if (StringUtils.isNotBlank(includeAll)) {
 			billSearch.setIncludeVoidedLineItems(Boolean.parseBoolean(includeAll));
+		}
+		
+		String startDate = context.getRequest().getParameter("startDate");
+		if (StringUtils.isNotBlank(startDate)) {
+			billSearch.setStartDate((Date) ConversionUtil.convert(startDate, Date.class));
+		}
+		
+		String endDate = context.getRequest().getParameter("endDate");
+		if (StringUtils.isNotBlank(endDate)) {
+			billSearch.setEndDate((Date) ConversionUtil.convert(endDate, Date.class));
 		}
 		
 		return billSearch;


### PR DESCRIPTION
### Summary
Adds optional `startDate` and `endDate` query parameters to the `GET /ws/rest/v1/billing/bill` endpoint to support date range filtering with server-side pagination.

### Changes
- **`BillSearch.java`**: Added `startDate` and `endDate` fields (`java.util.Date`).
- **`HibernateBillDAO.java`**: Added CriteriaBuilder predicates for `dateCreated >= startDate` and `dateCreated <= endDate`.
- **`BillResource.java`**: Extracted and parsed `startDate` & `endDate` query parameters using `ConversionUtil.convert`.
- **`HibernateBillDAOTest.java`**: Added unit tests for date filtering bounds.

### Related Issue
https://openmrs.atlassian.net/browse/O3-5112