### PR TITLE
O3-5835: Fix duplicate receipt numbers by reserving sequence blocks wth row locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The module provides several global properties for configuration:
 - `billing.defaultShiftReportId`: Jasper report ID for shift reports
 - `billing.receipt.logoPath`: Path to receipt logo image
 - `billing.systemReceiptNumberGenerator`: Class name for receipt number generator (default: `org.openmrs.module.billing.api.SequentialReceiptNumberGenerator`)
+- `billing.sequenceBlockSize`: Number of receipt sequence values reserved per database round-trip (default: 100). Larger blocks reduce database contention; smaller blocks reduce the sequence values skipped on restart (up to blockSize - 1 per group). Receipt numbers are always unique but may skip values.
 
 **Bill Rounding**:
 

--- a/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
+++ b/api/src/main/java/org/openmrs/module/billing/ModuleSettings.java
@@ -37,6 +37,8 @@ public class ModuleSettings {
 	
 	public static final String SYSTEM_RECEIPT_NUMBER_GENERATOR = "billing.systemReceiptNumberGenerator";
 	
+	public static final String SEQUENCE_BLOCK_SIZE_PROPERTY = "billing.sequenceBlockSize";
+	
 	public static final String ADJUSTMENT_REASON_FIELD = "billing.adjustmentReasonField";
 	
 	public static final String ALLOW_BILL_ADJUSTMENT = "billing.allowBillAdjustments";

--- a/api/src/main/java/org/openmrs/module/billing/api/ISequentialReceiptNumberGeneratorService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/ISequentialReceiptNumberGeneratorService.java
@@ -66,6 +66,7 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	 * @param blockSize The number of values to reserve.
 	 * @return The first value of the reserved block.
 	 * @should Reserve non overlapping blocks
+	 * @should Not hand out overlapping blocks under concurrency
 	 * @should Commit independently of an enclosing transaction
 	 * @should Throw IllegalArgumentException if the group is null
 	 * @should Throw IllegalArgumentException if blockSize is less than one

--- a/api/src/main/java/org/openmrs/module/billing/api/ISequentialReceiptNumberGeneratorService.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/ISequentialReceiptNumberGeneratorService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.openmrs.module.billing.api.base.entity.IObjectDataService;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -34,16 +35,43 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	SequentialReceiptNumberGeneratorModel getOnly();
 	
 	/**
-	 * Reserves the next sequence value for the specified group.
+	 * Reserves the next sequence value for the specified group. Values are handed out from an in-memory
+	 * pool backed by blocks reserved via {@link #reserveSequenceBlock(String, int)}, so the persisted
+	 * sequence value advances a block at a time. The block size is configured by the
+	 * {@code billing.sequenceBlockSize} global property (default 100).
+	 * <p>
+	 * Values may be skipped: a consumer whose transaction rolls back burns its value, and a restart or
+	 * module reload discards the unused remainder of the current block. Values are unique but not
+	 * gapless, and interleave (without colliding) across application servers.
+	 * </p>
 	 *
 	 * @param group The grouping value.
 	 * @return The next sequence value.
-	 * @should Increment and return the sequence value for existing groups
-	 * @should Create a new sequence with a value of one if the group does not exist
+	 * @should Return one and persist a full block for a new group
+	 * @should Hand out consecutive values from the pool
+	 * @should Continue from the persisted value for an existing group
+	 * @should Reserve a new block when the pool is drained
+	 * @should Use the block size from the global property
 	 * @should Throw IllegalArgumentException if the group is null
 	 */
 	@Transactional
 	int reserveNextSequence(String group);
+	
+	/**
+	 * Atomically reserves a contiguous block of sequence values for the specified group in its own
+	 * transaction, committed immediately and independently of any enclosing transaction. The reserved
+	 * block is {@code [first, first + blockSize - 1]} where {@code first} is the returned value.
+	 *
+	 * @param group The grouping value.
+	 * @param blockSize The number of values to reserve.
+	 * @return The first value of the reserved block.
+	 * @should Reserve non overlapping blocks
+	 * @should Commit independently of an enclosing transaction
+	 * @should Throw IllegalArgumentException if the group is null
+	 * @should Throw IllegalArgumentException if blockSize is less than one
+	 */
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	int reserveSequenceBlock(String group, int blockSize);
 	
 	/**
 	 * Returns all sequences.
@@ -69,7 +97,11 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	GroupSequence getSequence(String group);
 	
 	/**
-	 * Saves the sequence, creating a new sequences or updating an existing one.
+	 * Saves the sequence, creating a new sequences or updating an existing one. Once the transaction
+	 * commits, the in-memory reservation pool for the sequence's group is invalidated so future
+	 * reservations continue from the saved value. The invalidation is JVM-local: other nodes in a
+	 * cluster keep serving their already-reserved blocks, so manual sequence edits are not
+	 * cluster-safe.
 	 *
 	 * @param sequence The sequence to save.
 	 * @return The saved sequence.
@@ -77,6 +109,8 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	 * @should return the saved sequence
 	 * @should update the sequence successfully
 	 * @should create the sequence successfully
+	 * @should Invalidate the pool for the group
+	 * @should Not invalidate the pool when the transaction rolls back
 	 */
 	@Transactional
 	GroupSequence saveSequence(GroupSequence sequence);
@@ -88,6 +122,7 @@ public interface ISequentialReceiptNumberGeneratorService extends IObjectDataSer
 	 * @should Throw a NullPointerException if the sequence is null
 	 * @should delete the sequence from the database
 	 * @should not throw an exception if the sequence is not in the database
+	 * @should Invalidate the pool for the group
 	 */
 	@Transactional
 	void purgeSequence(GroupSequence sequence);

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.LockMode;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.exception.LockAcquisitionException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.billing.ModuleSettings;
 import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
@@ -25,6 +26,7 @@ import org.openmrs.module.billing.api.base.entity.impl.BaseObjectDataServiceImpl
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
 import org.openmrs.module.billing.api.security.BasicEntityAuthorizationPrivileges;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -195,7 +197,7 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 			return getProxy().reserveSequenceBlock(group, blockSize);
 		}
 		catch (RuntimeException ex) {
-			if (!isConstraintViolation(ex)) {
+			if (!isRetryable(ex)) {
 				throw ex;
 			}
 			
@@ -255,12 +257,12 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 		}
 	}
 	
-	private static boolean isConstraintViolation(Throwable ex) {
+	private static boolean isRetryable(Throwable ex) {
 		Throwable t = ex;
 		for (int depth = 0; t != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++) {
 			if (t instanceof org.hibernate.exception.ConstraintViolationException
-			        || t instanceof SQLIntegrityConstraintViolationException
-			        || t instanceof DataIntegrityViolationException) {
+			        || t instanceof SQLIntegrityConstraintViolationException || t instanceof DataIntegrityViolationException
+			        || t instanceof LockAcquisitionException || t instanceof ConcurrencyFailureException) {
 				return true;
 			}
 			t = t.getCause();

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
@@ -9,22 +9,53 @@
  */
 package org.openmrs.module.billing.api.impl;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.LockMode;
 import org.hibernate.criterion.Restrictions;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.ModuleSettings;
 import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
 import org.openmrs.module.billing.api.base.entity.impl.BaseObjectDataServiceImpl;
 import org.openmrs.module.billing.api.model.GroupSequence;
 import org.openmrs.module.billing.api.model.SequentialReceiptNumberGeneratorModel;
 import org.openmrs.module.billing.api.security.BasicEntityAuthorizationPrivileges;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Data service implementation class for {@link SequentialReceiptNumberGeneratorModel}s.
+ * <p>
+ * Sequence values are handed out from an in-memory per-group pool that is refilled by reserving
+ * blocks of values (size configured by the {@code billing.sequenceBlockSize} global property,
+ * default {@link #DEFAULT_SEQUENCE_BLOCK_SIZE}) in a separate, immediately-committed transaction
+ * that pessimistically locks the sequence row. This keeps concurrent reservations unique across
+ * threads and JVMs, at the cost of gaps in the sequence: a rolled-back consumer burns its value,
+ * and a restart discards the unused remainder of the current block.
+ * </p>
+ * <p>
+ * Pool invalidation on {@link #saveSequence} / {@link #purgeSequence} is JVM-local: other nodes in
+ * a cluster keep serving their already-reserved blocks. Manually editing a sequence value is
+ * therefore only safe when done on all nodes or while the other nodes are stopped.
+ * </p>
  */
+@Slf4j
 @Transactional
 public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataServiceImpl<SequentialReceiptNumberGeneratorModel, BasicEntityAuthorizationPrivileges> implements ISequentialReceiptNumberGeneratorService {
+	
+	public static final int DEFAULT_SEQUENCE_BLOCK_SIZE = 100;
+	
+	private static final int MAX_CAUSE_CHAIN_DEPTH = 10;
+	
+	private final ConcurrentHashMap<String, SequencePool> pools = new ConcurrentHashMap<>();
 	
 	@Override
 	protected BasicEntityAuthorizationPrivileges getPrivileges() {
@@ -51,23 +82,69 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 	@Override
 	@Transactional
 	public int reserveNextSequence(String group) {
-		// Get the sequence
-		GroupSequence sequence = getSequence(group);
-		if (sequence == null) {
-			// Sequence not found so create it
-			sequence = new GroupSequence();
-			sequence.setGroup(group);
-			sequence.setValue(1);
-		} else {
-			// Increment the value
-			sequence.setValue(sequence.getValue() + 1);
+		if (group == null) {
+			throw new IllegalArgumentException("The group must be defined.");
 		}
 		
-		// Store the sequence and save the updated or new sequence
-		int result = sequence.getValue();
-		saveSequence(sequence);
+		while (true) {
+			SequencePool pool = pools.computeIfAbsent(group, g -> new SequencePool());
+			if (pool.isInvalidated()) {
+				pools.remove(group, pool);
+				continue;
+			}
+			
+			Integer value = pool.tryTake();
+			if (value != null) {
+				return value;
+			}
+			
+			synchronized (pool.refillLock) {
+				value = pool.tryTake();
+				if (value != null) {
+					return value;
+				}
+				if (pool.isInvalidated()) {
+					continue;
+				}
+				
+				int blockSize = getBlockSize();
+				value = pool.refillAndTake(reserveBlockWithRetry(group, blockSize), blockSize);
+				if (value != null) {
+					return value;
+				}
+			}
+		}
+	}
+	
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public int reserveSequenceBlock(String group, int blockSize) {
+		if (group == null) {
+			throw new IllegalArgumentException("The group must be defined.");
+		}
+		if (blockSize < 1) {
+			throw new IllegalArgumentException("The block size must be at least one.");
+		}
 		
-		return result;
+		Criteria criteria = getRepository().createCriteria(GroupSequence.class);
+		criteria.add(Restrictions.eq("group", group));
+		criteria.setLockMode(LockMode.PESSIMISTIC_WRITE);
+		GroupSequence sequence = getRepository().selectSingle(GroupSequence.class, criteria);
+		
+		int first;
+		if (sequence == null) {
+			sequence = new GroupSequence();
+			sequence.setGroup(group);
+			sequence.setValue(blockSize);
+			first = 1;
+		} else {
+			first = sequence.getValue() + 1;
+			sequence.setValue(sequence.getValue() + blockSize);
+		}
+		
+		getRepository().save(sequence);
+		
+		return first;
 	}
 	
 	@Override
@@ -96,7 +173,10 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 			throw new NullPointerException("The sequence to save must be defined.");
 		}
 		
-		return getRepository().save(sequence);
+		GroupSequence result = getRepository().save(sequence);
+		invalidatePoolAfterCommit(sequence.getGroup());
+		
+		return result;
 	}
 	
 	@Override
@@ -107,5 +187,123 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 		}
 		
 		getRepository().delete(sequence);
+		invalidatePoolAfterCommit(sequence.getGroup());
+	}
+	
+	private int reserveBlockWithRetry(String group, int blockSize) {
+		try {
+			return getProxy().reserveSequenceBlock(group, blockSize);
+		}
+		catch (RuntimeException ex) {
+			if (!isConstraintViolation(ex)) {
+				throw ex;
+			}
+			
+			return getProxy().reserveSequenceBlock(group, blockSize);
+		}
+	}
+	
+	protected ISequentialReceiptNumberGeneratorService getProxy() {
+		return Context.getService(ISequentialReceiptNumberGeneratorService.class);
+	}
+	
+	protected int getBlockSize() {
+		String property = Context.getAdministrationService().getGlobalProperty(ModuleSettings.SEQUENCE_BLOCK_SIZE_PROPERTY);
+		if (StringUtils.isNotBlank(property)) {
+			try {
+				int blockSize = Integer.parseInt(property.trim());
+				if (blockSize >= 1) {
+					return blockSize;
+				}
+				log.warn("Ignoring global property {}={}; the block size must be at least one.",
+				    ModuleSettings.SEQUENCE_BLOCK_SIZE_PROPERTY, property);
+			}
+			catch (NumberFormatException ex) {
+				log.warn("Ignoring non-numeric global property {}={}.", ModuleSettings.SEQUENCE_BLOCK_SIZE_PROPERTY,
+				    property);
+			}
+		}
+		
+		return DEFAULT_SEQUENCE_BLOCK_SIZE;
+	}
+	
+	// Invalidating before commit blocks concurrent refills on this transaction's row lock,
+	// and a rollback would discard a still-valid pool
+	private void invalidatePoolAfterCommit(String group) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				
+				@Override
+				public void afterCommit() {
+					invalidatePool(group);
+				}
+			});
+		} else {
+			invalidatePool(group);
+		}
+	}
+	
+	void invalidatePool(String group) {
+		if (group == null) {
+			return;
+		}
+		
+		SequencePool pool = pools.get(group);
+		if (pool != null) {
+			pool.invalidate();
+			pools.remove(group, pool);
+		}
+	}
+	
+	private static boolean isConstraintViolation(Throwable ex) {
+		Throwable t = ex;
+		for (int depth = 0; t != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++) {
+			if (t instanceof org.hibernate.exception.ConstraintViolationException
+			        || t instanceof SQLIntegrityConstraintViolationException
+			        || t instanceof DataIntegrityViolationException) {
+				return true;
+			}
+			t = t.getCause();
+		}
+		
+		return false;
+	}
+	
+	private static final class SequencePool {
+		
+		private final Object refillLock = new Object();
+		
+		private int next = 1;
+		
+		private int max = 0;
+		
+		private boolean invalidated = false;
+		
+		synchronized boolean isInvalidated() {
+			return invalidated;
+		}
+		
+		synchronized void invalidate() {
+			invalidated = true;
+		}
+		
+		synchronized Integer tryTake() {
+			if (invalidated || next > max) {
+				return null;
+			}
+			
+			return next++;
+		}
+		
+		synchronized Integer refillAndTake(int first, int blockSize) {
+			if (invalidated) {
+				return null;
+			}
+			
+			next = first;
+			max = first + blockSize - 1;
+			
+			return next++;
+		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorServiceImpl.java
@@ -89,32 +89,38 @@ public class SequentialReceiptNumberGeneratorServiceImpl extends BaseObjectDataS
 		}
 		
 		while (true) {
-			SequencePool pool = pools.computeIfAbsent(group, g -> new SequencePool());
-			if (pool.isInvalidated()) {
-				pools.remove(group, pool);
-				continue;
-			}
-			
-			Integer value = pool.tryTake();
+			Integer value = tryReserveFromPool(group);
 			if (value != null) {
 				return value;
 			}
-			
-			synchronized (pool.refillLock) {
-				value = pool.tryTake();
-				if (value != null) {
-					return value;
-				}
-				if (pool.isInvalidated()) {
-					continue;
-				}
-				
-				int blockSize = getBlockSize();
-				value = pool.refillAndTake(reserveBlockWithRetry(group, blockSize), blockSize);
-				if (value != null) {
-					return value;
-				}
+		}
+	}
+	
+	// Returns null when the pool was invalidated concurrently and the reservation must be retried
+	private Integer tryReserveFromPool(String group) {
+		SequencePool pool = pools.computeIfAbsent(group, g -> new SequencePool());
+		if (pool.isInvalidated()) {
+			pools.remove(group, pool);
+			return null;
+		}
+		
+		Integer value = pool.tryTake();
+		if (value != null) {
+			return value;
+		}
+		
+		// The DB round-trip must not run under the pool monitor: it deadlocks against invalidatePool
+		synchronized (pool.refillLock) {
+			value = pool.tryTake();
+			if (value != null) {
+				return value;
 			}
+			if (pool.isInvalidated()) {
+				return null;
+			}
+			
+			int blockSize = getBlockSize();
+			return pool.refillAndTake(reserveBlockWithRetry(group, blockSize), blockSize);
 		}
 	}
 	

--- a/api/src/main/resources/SequentialReceiptNumberGenerator.hbm.xml
+++ b/api/src/main/resources/SequentialReceiptNumberGenerator.hbm.xml
@@ -48,8 +48,6 @@
 	</class>
 
 	<class name="org.openmrs.module.billing.api.model.GroupSequence" table="cashier_seq_group_sequence">
-		<cache usage="read-write"/>
-
 		<id name="id" type="int" column="seq_group_sequence_id">
 			<generator class="native">
 				<param name="sequence">cashier_seq_group_sequence_seq_group_sequence_id_seq</param>

--- a/api/src/test/java/org/openmrs/module/billing/ISequentialReceiptNumberGeneratorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/ISequentialReceiptNumberGeneratorServiceTest.java
@@ -65,15 +65,6 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 		return model;
 	}
 	
-	protected GroupSequence createSequence(String group, int value) {
-		GroupSequence result = new GroupSequence();
-		
-		result.setGroup(group);
-		result.setValue(value);
-		
-		return result;
-	}
-	
 	@Override
 	protected int getTestEntityCount() {
 		return 1;
@@ -100,67 +91,6 @@ public class ISequentialReceiptNumberGeneratorServiceTest extends IObjectDataSer
 		Assert.assertEquals(expected.getSequencePadding(), actual.getSequencePadding());
 		Assert.assertEquals(expected.getSequenceType(), actual.getSequenceType());
 		Assert.assertEquals(expected.getIncludeCheckDigit(), actual.getIncludeCheckDigit());
-	}
-	
-	/**
-	 * @verifies Increment and return the sequence value for existing groups
-	 * @see ISequentialReceiptNumberGeneratorService#reserveNextSequence(String)
-	 */
-	@Test
-	public void reserveNextSequence_shouldIncrementAndReturnTheSequenceValueForExistingGroups() {
-		GroupSequence sequence = createSequence("test", 1);
-		service.saveSequence(sequence);
-		sequence = createSequence("test2", 53);
-		service.saveSequence(sequence);
-		sequence = createSequence("test3", 10);
-		service.saveSequence(sequence);
-		Context.flushSession();
-		
-		int result = service.reserveNextSequence("test");
-		Assert.assertEquals(2, result);
-		sequence = service.getSequence("test");
-		Assert.assertNotNull(sequence);
-		Assert.assertEquals(2, sequence.getValue());
-		Context.flushSession();
-		
-		result = service.reserveNextSequence("test");
-		Assert.assertEquals(3, result);
-		sequence = service.getSequence("test");
-		Assert.assertNotNull(sequence);
-		Assert.assertEquals(3, sequence.getValue());
-		Context.flushSession();
-		
-		result = service.reserveNextSequence("test2");
-		Assert.assertEquals(54, result);
-		sequence = service.getSequence("test2");
-		Assert.assertNotNull(sequence);
-		Assert.assertEquals(54, sequence.getValue());
-		Context.flushSession();
-		
-		result = service.reserveNextSequence("test3");
-		Assert.assertEquals(11, result);
-		sequence = service.getSequence("test3");
-		Assert.assertNotNull(sequence);
-		Assert.assertEquals(11, sequence.getValue());
-	}
-	
-	/**
-	 * @verifies Create a new sequence with a value of one if the group does not exist
-	 * @see ISequentialReceiptNumberGeneratorService#reserveNextSequence(String)
-	 */
-	@Test
-	public void reserveNextSequence_shouldCreateANewSequenceWithAValueOfOneIfTheGroupDoesNotExist() {
-		GroupSequence sequence = service.getSequence("test");
-		Assert.assertNull(sequence);
-		
-		int result = service.reserveNextSequence("test");
-		Assert.assertEquals(1, result);
-		
-		Context.flushSession();
-		
-		sequence = service.getSequence("test");
-		Assert.assertNotNull(sequence);
-		Assert.assertEquals(1, sequence.getValue());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorReserveTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorReserveTest.java
@@ -1,0 +1,194 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.openmrs.module.billing.api.impl.SequentialReceiptNumberGeneratorServiceImpl;
+import org.openmrs.module.billing.api.model.GroupSequence;
+import org.openmrs.module.billing.base.BaseModuleContextTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Tests for sequence reservation. These run without a test-managed transaction because
+ * {@link ISequentialReceiptNumberGeneratorService#reserveSequenceBlock(String, int)} commits in a
+ * REQUIRES_NEW transaction on a separate connection, which would block on this class's uncommitted
+ * data if the tests were transactional. Every service call commits immediately, so fixtures are
+ * created through the service and all rows are purged after each test.
+ */
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class SequentialReceiptNumberGeneratorReserveTest extends BaseModuleContextTest {
+	
+	private static final int BLOCK_SIZE = SequentialReceiptNumberGeneratorServiceImpl.DEFAULT_SEQUENCE_BLOCK_SIZE;
+	
+	private ISequentialReceiptNumberGeneratorService service;
+	
+	@Before
+	public void before() {
+		service = Context.getService(ISequentialReceiptNumberGeneratorService.class);
+	}
+	
+	@After
+	public void purgeAllSequences() {
+		Context.clearSession();
+		for (GroupSequence sequence : service.getSequences()) {
+			service.purgeSequence(sequence);
+		}
+		Context.getAdministrationService().setGlobalProperty(ModuleSettings.SEQUENCE_BLOCK_SIZE_PROPERTY, "");
+	}
+	
+	private GroupSequence createSequence(String group, int value) {
+		GroupSequence sequence = new GroupSequence();
+		sequence.setGroup(group);
+		sequence.setValue(value);
+		
+		return sequence;
+	}
+	
+	private int persistedValue(String group) {
+		Context.clearSession();
+		GroupSequence sequence = service.getSequence(group);
+		Assert.assertNotNull("Expected a persisted sequence for group '" + group + "'", sequence);
+		
+		return sequence.getValue();
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldReturnOneAndPersistAFullBlockForANewGroup() {
+		int result = service.reserveNextSequence("reserve-new-group");
+		
+		Assert.assertEquals(1, result);
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-new-group"));
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldHandOutConsecutiveValuesFromThePool() {
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-consecutive"));
+		Assert.assertEquals(2, service.reserveNextSequence("reserve-consecutive"));
+		Assert.assertEquals(3, service.reserveNextSequence("reserve-consecutive"));
+		
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-consecutive"));
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldContinueFromThePersistedValueForAnExistingGroup() {
+		service.saveSequence(createSequence("reserve-existing", 10));
+		
+		int result = service.reserveNextSequence("reserve-existing");
+		
+		Assert.assertEquals(11, result);
+		Assert.assertEquals(10 + BLOCK_SIZE, persistedValue("reserve-existing"));
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldReserveANewBlockWhenThePoolIsDrained() {
+		for (int i = 1; i <= BLOCK_SIZE; i++) {
+			Assert.assertEquals(i, service.reserveNextSequence("reserve-drain"));
+		}
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-drain"));
+		
+		Assert.assertEquals(BLOCK_SIZE + 1, service.reserveNextSequence("reserve-drain"));
+		Assert.assertEquals(2 * BLOCK_SIZE, persistedValue("reserve-drain"));
+	}
+	
+	@Test
+	public void saveSequence_shouldInvalidateThePoolForTheGroup() {
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-save-invalidate"));
+		
+		Context.clearSession();
+		GroupSequence sequence = service.getSequence("reserve-save-invalidate");
+		sequence.setValue(500);
+		service.saveSequence(sequence);
+		
+		Assert.assertEquals(501, service.reserveNextSequence("reserve-save-invalidate"));
+		Assert.assertEquals(500 + BLOCK_SIZE, persistedValue("reserve-save-invalidate"));
+	}
+	
+	@Test
+	public void purgeSequence_shouldInvalidateThePoolForTheGroup() {
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-purge-invalidate"));
+		
+		Context.clearSession();
+		service.purgeSequence(service.getSequence("reserve-purge-invalidate"));
+		
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-purge-invalidate"));
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-purge-invalidate"));
+	}
+	
+	@Test
+	public void reserveSequenceBlock_shouldReserveNonOverlappingBlocks() {
+		Assert.assertEquals(1, service.reserveSequenceBlock("reserve-block", BLOCK_SIZE));
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-block"));
+		
+		Assert.assertEquals(BLOCK_SIZE + 1, service.reserveSequenceBlock("reserve-block", BLOCK_SIZE));
+		Assert.assertEquals(2 * BLOCK_SIZE, persistedValue("reserve-block"));
+		
+		Assert.assertEquals(2 * BLOCK_SIZE + 1, service.reserveSequenceBlock("reserve-block", 5));
+		Assert.assertEquals(2 * BLOCK_SIZE + 5, persistedValue("reserve-block"));
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldUseTheBlockSizeFromTheGlobalProperty() {
+		Context.getAdministrationService().setGlobalProperty(ModuleSettings.SEQUENCE_BLOCK_SIZE_PROPERTY, "10");
+		
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-gp-block-size"));
+		Assert.assertEquals(10, persistedValue("reserve-gp-block-size"));
+	}
+	
+	@Test
+	public void reserveSequenceBlock_shouldCommitIndependentlyOfAnEnclosingTransaction() {
+		Integer first = newTransactionTemplate().execute(status -> {
+			int result = service.reserveSequenceBlock("reserve-outer-rollback", BLOCK_SIZE);
+			status.setRollbackOnly();
+			return result;
+		});
+		
+		Assert.assertEquals((Integer) 1, first);
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-outer-rollback"));
+	}
+	
+	@Test
+	public void saveSequence_shouldNotInvalidateThePoolWhenTheTransactionRollsBack() {
+		Assert.assertEquals(1, service.reserveNextSequence("reserve-rollback-save"));
+		
+		newTransactionTemplate().execute(status -> {
+			Context.clearSession();
+			GroupSequence sequence = service.getSequence("reserve-rollback-save");
+			sequence.setValue(500);
+			service.saveSequence(sequence);
+			status.setRollbackOnly();
+			return null;
+		});
+		
+		Assert.assertEquals(2, service.reserveNextSequence("reserve-rollback-save"));
+		Assert.assertEquals(BLOCK_SIZE, persistedValue("reserve-rollback-save"));
+	}
+	
+	private TransactionTemplate newTransactionTemplate() {
+		return new TransactionTemplate(applicationContext.getBean("transactionManager", PlatformTransactionManager.class));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void reserveSequenceBlock_shouldThrowIllegalArgumentExceptionIfTheGroupIsNull() {
+		service.reserveSequenceBlock(null, BLOCK_SIZE);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void reserveSequenceBlock_shouldThrowIllegalArgumentExceptionIfBlockSizeIsLessThanOne() {
+		service.reserveSequenceBlock("reserve-block-invalid", 0);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorReserveTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/SequentialReceiptNumberGeneratorReserveTest.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.billing;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -180,6 +186,47 @@ public class SequentialReceiptNumberGeneratorReserveTest extends BaseModuleConte
 	
 	private TransactionTemplate newTransactionTemplate() {
 		return new TransactionTemplate(applicationContext.getBean("transactionManager", PlatformTransactionManager.class));
+	}
+	
+	@Test
+	public void reserveSequenceBlock_shouldNotHandOutOverlappingBlocksUnderConcurrency() throws Exception {
+		service.reserveSequenceBlock("reserve-lock", 1);
+		
+		final ConcurrentLinkedQueue<Integer> firsts = new ConcurrentLinkedQueue<>();
+		final ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+		final CountDownLatch start = new CountDownLatch(1);
+		
+		List<Thread> threads = new ArrayList<>();
+		for (int i = 0; i < 4; i++) {
+			Thread thread = new Thread(() -> {
+				Context.openSession();
+				try {
+					start.await();
+					ISequentialReceiptNumberGeneratorService threadService = Context
+					        .getService(ISequentialReceiptNumberGeneratorService.class);
+					for (int call = 0; call < 25; call++) {
+						firsts.add(threadService.reserveSequenceBlock("reserve-lock", 10));
+					}
+				}
+				catch (Throwable t) {
+					failures.add(t);
+				}
+				finally {
+					Context.closeSession();
+				}
+			});
+			threads.add(thread);
+			thread.start();
+		}
+		
+		start.countDown();
+		for (Thread thread : threads) {
+			thread.join(180000);
+		}
+		
+		Assert.assertTrue("Worker threads failed: " + failures, failures.isEmpty());
+		Assert.assertEquals(100, firsts.size());
+		Assert.assertEquals("Overlapping blocks were handed out", 100, new HashSet<>(firsts).size());
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorPoolTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorPoolTest.java
@@ -1,0 +1,171 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.billing.api.impl;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Tests the in-memory pool distribution of
+ * {@link SequentialReceiptNumberGeneratorServiceImpl#reserveNextSequence(String)} without a
+ * database: the block reservation proxy is replaced with an atomic in-memory counter.
+ */
+public class SequentialReceiptNumberGeneratorPoolTest {
+	
+	private static final int BLOCK_SIZE = SequentialReceiptNumberGeneratorServiceImpl.DEFAULT_SEQUENCE_BLOCK_SIZE;
+	
+	private ISequentialReceiptNumberGeneratorService blockReserver;
+	
+	private SequentialReceiptNumberGeneratorServiceImpl service;
+	
+	@Before
+	public void before() {
+		blockReserver = mock(ISequentialReceiptNumberGeneratorService.class);
+		
+		ConcurrentHashMap<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+		when(blockReserver.reserveSequenceBlock(anyString(), anyInt())).thenAnswer(invocation -> {
+			String group = invocation.getArgument(0);
+			int blockSize = invocation.getArgument(1);
+			
+			return counters.computeIfAbsent(group, g -> new AtomicInteger()).getAndAdd(blockSize) + 1;
+		});
+		
+		service = new SequentialReceiptNumberGeneratorServiceImpl() {
+			
+			@Override
+			protected ISequentialReceiptNumberGeneratorService getProxy() {
+				return blockReserver;
+			}
+			
+			@Override
+			protected int getBlockSize() {
+				return BLOCK_SIZE;
+			}
+		};
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldHandOutUniqueGaplessValuesUnderConcurrency() throws Exception {
+		final int threadCount = 20;
+		final int callsPerThread = 500;
+		final int total = threadCount * callsPerThread;
+		
+		final ConcurrentLinkedQueue<Integer> results = new ConcurrentLinkedQueue<>();
+		final ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+		final CountDownLatch start = new CountDownLatch(1);
+		
+		List<Thread> threads = new ArrayList<>();
+		for (int i = 0; i < threadCount; i++) {
+			Thread thread = new Thread(() -> {
+				try {
+					start.await();
+					for (int call = 0; call < callsPerThread; call++) {
+						results.add(service.reserveNextSequence("main"));
+						service.reserveNextSequence("other");
+					}
+				}
+				catch (Throwable t) {
+					failures.add(t);
+				}
+			});
+			threads.add(thread);
+			thread.start();
+		}
+		
+		start.countDown();
+		for (Thread thread : threads) {
+			thread.join(60000);
+		}
+		
+		Assert.assertTrue("Worker threads failed: " + failures, failures.isEmpty());
+		Assert.assertEquals(total, results.size());
+		
+		Set<Integer> unique = new HashSet<>(results);
+		Assert.assertEquals("Duplicate sequence values were handed out", total, unique.size());
+		Assert.assertTrue(unique.contains(1));
+		Assert.assertTrue(unique.contains(total));
+		
+		verify(blockReserver, times(total / BLOCK_SIZE)).reserveSequenceBlock("main", BLOCK_SIZE);
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldRetryOnceWhenBlockReservationHitsAConstraintViolation() {
+		when(blockReserver.reserveSequenceBlock("race", BLOCK_SIZE))
+		        .thenThrow(new DataIntegrityViolationException("duplicate", new ConstraintViolationException("duplicate",
+		                new SQLIntegrityConstraintViolationException(), "cashier_seq_group_sequence")))
+		        .thenReturn(1);
+		
+		Assert.assertEquals(1, service.reserveNextSequence("race"));
+		
+		verify(blockReserver, times(2)).reserveSequenceBlock("race", BLOCK_SIZE);
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldNotRetryOnOtherExceptions() {
+		when(blockReserver.reserveSequenceBlock("failing", BLOCK_SIZE)).thenThrow(new IllegalStateException("boom"));
+		
+		try {
+			service.reserveNextSequence("failing");
+			Assert.fail("Expected IllegalStateException");
+		}
+		catch (IllegalStateException expected) {}
+		
+		verify(blockReserver, times(1)).reserveSequenceBlock("failing", BLOCK_SIZE);
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldDiscardABlockReservedWhileThePoolWasInvalidated() {
+		final AtomicInteger calls = new AtomicInteger();
+		when(blockReserver.reserveSequenceBlock("invalidated", BLOCK_SIZE)).thenAnswer(invocation -> {
+			if (calls.incrementAndGet() == 1) {
+				service.invalidatePool("invalidated");
+				return 1;
+			}
+			return 501;
+		});
+		
+		Assert.assertEquals(501, service.reserveNextSequence("invalidated"));
+		
+		verify(blockReserver, times(2)).reserveSequenceBlock("invalidated", BLOCK_SIZE);
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldThrowIllegalArgumentExceptionIfTheGroupIsNull() {
+		try {
+			service.reserveNextSequence(null);
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {}
+		
+		verify(blockReserver, never()).reserveSequenceBlock(anyString(), anyInt());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorPoolTest.java
+++ b/api/src/test/java/org/openmrs/module/billing/api/impl/SequentialReceiptNumberGeneratorPoolTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -28,10 +29,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.billing.api.ISequentialReceiptNumberGeneratorService;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
 
 /**
@@ -127,6 +130,18 @@ public class SequentialReceiptNumberGeneratorPoolTest {
 		Assert.assertEquals(1, service.reserveNextSequence("race"));
 		
 		verify(blockReserver, times(2)).reserveSequenceBlock("race", BLOCK_SIZE);
+	}
+	
+	@Test
+	public void reserveNextSequence_shouldRetryOnceWhenBlockReservationHitsADeadlock() {
+		when(blockReserver.reserveSequenceBlock("deadlock", BLOCK_SIZE))
+		        .thenThrow(new CannotAcquireLockException("deadlock",
+		                new LockAcquisitionException("deadlock", new SQLException("Deadlock found", "40001", 1213))))
+		        .thenReturn(1);
+		
+		Assert.assertEquals(1, service.reserveNextSequence("deadlock"));
+		
+		verify(blockReserver, times(2)).reserveSequenceBlock("deadlock", BLOCK_SIZE);
 	}
 	
 	@Test

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -78,6 +78,15 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>${project.parent.artifactId}.sequenceBlockSize</property>
+		<description>Number of receipt sequence values reserved per database round-trip. Larger blocks
+			reduce database contention but increase the sequence values skipped on restart (up to
+			blockSize - 1 per group). Must be at least 1; defaults to 100.
+		</description>
+		<defaultValue>100</defaultValue>
+	</globalProperty>
+
+	<globalProperty>
 		<property>${project.parent.artifactId}.roundingItemId</property>
 		<description>ID of the item used to account for bill total rounding.</description>
 	</globalProperty>


### PR DESCRIPTION
Add reserveSequenceBlock(): locks the sequence row (SELECT ... FOR UPDATE) and reserves 100 numbers in an immediately-committed REQUIRES_NEWtransaction

https://openmrs.atlassian.net/browse/O3-5835